### PR TITLE
Allow skip onboarding for debugging and testing purposes

### DIFF
--- a/TidepoolOnboarding.xcodeproj/project.pbxproj
+++ b/TidepoolOnboarding.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		A923335D25C3789800D8CF69 /* WelcomeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A923334B25C3789700D8CF69 /* WelcomeViews.swift */; };
 		A923336525C3789800D8CF69 /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A923335525C3789800D8CF69 /* ActionButton.swift */; };
 		A923336725C3789800D8CF69 /* ContentPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A923335825C3789800D8CF69 /* ContentPreview.swift */; };
+		A93D2B112602606E0091FB65 /* AbortOnLongPressGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93D2B102602606E0091FB65 /* AbortOnLongPressGesture.swift */; };
 		A95422D325CC9A74003F3080 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95422D225CC9A74003F3080 /* Image.swift */; };
 		A98AD2BE25830807001AAD6F /* TidepoolOnboardingPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = A98AD2BC25830807001AAD6F /* TidepoolOnboardingPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A98AD2D325830843001AAD6F /* TidepoolOnboardingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A98AD2CA25830842001AAD6F /* TidepoolOnboardingKit.framework */; };
@@ -142,6 +143,7 @@
 		A923334B25C3789700D8CF69 /* WelcomeViews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeViews.swift; sourceTree = "<group>"; };
 		A923335525C3789800D8CF69 /* ActionButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
 		A923335825C3789800D8CF69 /* ContentPreview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentPreview.swift; sourceTree = "<group>"; };
+		A93D2B102602606E0091FB65 /* AbortOnLongPressGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbortOnLongPressGesture.swift; sourceTree = "<group>"; };
 		A95422D225CC9A74003F3080 /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		A98AD2B925830807001AAD6F /* TidepoolOnboardingPlugin.loopplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TidepoolOnboardingPlugin.loopplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		A98AD2BC25830807001AAD6F /* TidepoolOnboardingPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TidepoolOnboardingPlugin.h; sourceTree = "<group>"; };
@@ -436,6 +438,7 @@
 		A9A5629125F86DAB00A272B9 /* View Modifiers */ = {
 			isa = PBXGroup;
 			children = (
+				A93D2B102602606E0091FB65 /* AbortOnLongPressGesture.swift */,
 				A9A5624F25F8224B00A272B9 /* TransparentNavigationBar.swift */,
 			);
 			path = "View Modifiers";
@@ -878,6 +881,7 @@
 				A9BEF06C2588380F00860217 /* PrescriptionCodeEntryView.swift in Sources */,
 				A923334225C3786100D8CF69 /* Environment+Complete.swift in Sources */,
 				A916AA5125F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift in Sources */,
+				A93D2B112602606E0091FB65 /* AbortOnLongPressGesture.swift in Sources */,
 				A9EBBD3D25F984560064804A /* OnboardingSectionSheetButton.swift in Sources */,
 				A99EAA9B25F7FCF700503A6D /* ADayInTheLifeViews.swift in Sources */,
 				A923334125C3786100D8CF69 /* TimeInterval.swift in Sources */,

--- a/TidepoolOnboardingKitUI/View Models/OnboardingViewModel.swift
+++ b/TidepoolOnboardingKitUI/View Models/OnboardingViewModel.swift
@@ -83,6 +83,26 @@ class OnboardingViewModel: ObservableObject, CGMManagerCreateNotifying, CGMManag
     func durationStringForSection(_ section: OnboardingSection) -> String {
         return String(format: LocalizedString("%d min.", comment: "Section duration with minutes units (1: section duration in minutes)"), Int(durationForSection(section).minutes))
     }
+
+    // NOTE: SKIP ONBOARDING - DEBUG AND TEST ONLY
+
+    var allowSkipOnboarding: Bool { onboardingProvider.allowSkipOnboarding }
+
+    func skipOnboarding() {
+        guard allowSkipOnboarding else { return }
+
+        OnboardingSection.allCases.forEach { section in
+            if !sectionProgression.hasStartedSection(section) {
+                sectionProgression.startSection(section)
+            }
+            if !sectionProgression.hasCompletedSection(section) {
+                if section == .yourSettings {
+                    self.therapySettings = .mockTherapySettings     // If therapy settings not completed, then use mock therapy settings
+                }
+                sectionProgression.completeSection(section)
+            }
+        }
+    }
 }
 
 extension OnboardingViewModel: CGMManagerCreateDelegate {

--- a/TidepoolOnboardingKitUI/View Modifiers/AbortOnLongPressGesture.swift
+++ b/TidepoolOnboardingKitUI/View Modifiers/AbortOnLongPressGesture.swift
@@ -1,0 +1,46 @@
+//
+//  AbortOnLongPressGesture.swift
+//  TidepoolOnboardingKitUI
+//
+//  Created by Darin Krauss on 3/17/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    func abortOnLongPressGesture(enabled: Bool = true, minimumDuration: Double = 2, perform action: @escaping () -> Void) -> some View {
+        modifier(AbortOnLongPressGesture(enabled: enabled, minimumDuration: minimumDuration, perform: action))
+    }
+}
+
+fileprivate struct AbortOnLongPressGesture: ViewModifier {
+    @State private var isAlertPresented = false
+
+    private let enabled: Bool
+    private let minimumDuration: Double
+    private let action: () -> Void
+
+    init(enabled: Bool, minimumDuration: Double, perform action: @escaping () -> Void) {
+        self.enabled = enabled
+        self.minimumDuration = minimumDuration
+        self.action = action
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onLongPressGesture(minimumDuration: minimumDuration) {
+                if enabled {
+                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                    isAlertPresented = true
+                }
+            }
+            .alert(isPresented: $isAlertPresented) { alert }
+    }
+
+    private var alert: Alert {
+        Alert(title: Text("Are you sure you want to abort?"),
+              primaryButton: .cancel { isAlertPresented = false },
+              secondaryButton: .destructive(Text("Abort"), action: action))
+    }
+}

--- a/TidepoolOnboardingKitUI/Views/GettingToKnowTidepoolLoopView.swift
+++ b/TidepoolOnboardingKitUI/Views/GettingToKnowTidepoolLoopView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 import LoopKitUI
 
 struct GettingToKnowTidepoolLoopView: View {
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+
     var body: some View {
         ZStack {
             Color(.systemGroupedBackground)
@@ -32,6 +34,9 @@ struct GettingToKnowTidepoolLoopView: View {
             .bold()
             .fixedSize(horizontal: false, vertical: true)
             .accessibilityAddTraits(.isHeader)
+            .abortOnLongPressGesture(enabled: onboardingViewModel.allowSkipOnboarding) {
+                onboardingViewModel.skipOnboarding()   // NOTE: SKIP ONBOARDING - DEBUG AND TEST ONLY
+            }
     }
 
     private var description: some View {

--- a/TidepoolOnboardingKitUI/Views/Previews/OnboardingViewModel+Preview.swift
+++ b/TidepoolOnboardingKitUI/Views/Previews/OnboardingViewModel+Preview.swift
@@ -14,6 +14,8 @@ extension OnboardingViewModel {
 }
 
 fileprivate class PreviewOnboardingProvider: OnboardingProvider {
+    var allowSkipOnboarding: Bool = true
+
     func getNotificationAuthorization(_ completion: @escaping (NotificationAuthorization) -> Void) { completion(.notDetermined) }
     func authorizeNotification(_ completion: @escaping (NotificationAuthorization) -> Void) { completion(.notDetermined) }
 

--- a/TidepoolOnboardingKitUITests/Mocks/MockOnboardingProvider.swift
+++ b/TidepoolOnboardingKitUITests/Mocks/MockOnboardingProvider.swift
@@ -3,12 +3,15 @@
 //  TidepoolOnboardingKitUITests
 //
 //  Created by Darin Krauss on 3/12/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
 //
 
 import LoopKit
 import LoopKitUI
 
 class MockOnboardingProvider: OnboardingProvider {
+    var allowSkipOnboarding: Bool = true
+
     func getNotificationAuthorization(_ completion: @escaping (NotificationAuthorization) -> Void) { completion(.notDetermined) }
     func authorizeNotification(_ completion: @escaping (NotificationAuthorization) -> Void) { completion(.notDetermined) }
 


### PR DESCRIPTION
- Allows the user to force skip onboarding on an extra long press (> 2 seconds) on the Getting to Know Tidepool Loop title. 
- Ultimately, only available if `FeatureFlags.mockTherapySettingsEnabled` is `true` in `Loop`.
- Will use mock therapy settings only if not already set. 