### PR TITLE
[LOOP-3464, LOOP-3465] Integrate pump and CGM managers into onboarding

### DIFF
--- a/TidepoolOnboarding.xcodeproj/project.pbxproj
+++ b/TidepoolOnboarding.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		A906344A26433B9300CAFED1 /* TidepoolServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A906344926433B9300CAFED1 /* TidepoolServiceView.swift */; };
 		A90634562643426900CAFED1 /* OnboardingSectionWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90634552643426900CAFED1 /* OnboardingSectionWrapperView.swift */; };
 		A90E9F8826057CAF00566ED4 /* DemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90E9F8726057CAF00566ED4 /* DemoView.swift */; };
+		A911C236264B284D00EF3B85 /* AttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A911C235264B284D00EF3B85 /* AttributedStringTests.swift */; };
 		A916AA5125F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A916AA5025F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift */; };
 		A916AA5925F6F07100B7CEF2 /* DisplayGlucoseUnitObservable+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A916AA5825F6F07100B7CEF2 /* DisplayGlucoseUnitObservable+Preview.swift */; };
 		A91F7C94260524A0008FBAED /* CompleteDismissView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91F7C93260524A0008FBAED /* CompleteDismissView.swift */; };
@@ -54,6 +55,8 @@
 		A9502CF8260029A000146AD3 /* CheckmarkedBodyTextList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9502CF7260029A000146AD3 /* CheckmarkedBodyTextList.swift */; };
 		A95422D325CC9A74003F3080 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95422D225CC9A74003F3080 /* Image.swift */; };
 		A95BB9122603230B00E9FD17 /* Callout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95BB9112603230B00E9FD17 /* Callout.swift */; };
+		A95D62402649FF410018B9EA /* AttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95D623F2649FF410018B9EA /* AttributedString.swift */; };
+		A95D624C264A006D0018B9EA /* Text+AttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95D624B264A006C0018B9EA /* Text+AttributedString.swift */; };
 		A967D849261FB121009D9675 /* NavigationBarAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A967D848261FB121009D9675 /* NavigationBarAppearance.swift */; };
 		A98AD2BE25830807001AAD6F /* TidepoolOnboardingPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = A98AD2BC25830807001AAD6F /* TidepoolOnboardingPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A98AD2F225830851001AAD6F /* TidepoolOnboarding.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A98AD2E925830851001AAD6F /* TidepoolOnboarding.framework */; };
@@ -129,6 +132,7 @@
 		A906344926433B9300CAFED1 /* TidepoolServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolServiceView.swift; sourceTree = "<group>"; };
 		A90634552643426900CAFED1 /* OnboardingSectionWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSectionWrapperView.swift; sourceTree = "<group>"; };
 		A90E9F8726057CAF00566ED4 /* DemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoView.swift; sourceTree = "<group>"; };
+		A911C235264B284D00EF3B85 /* AttributedStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedStringTests.swift; sourceTree = "<group>"; };
 		A916AA5025F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingViewModel+Preview.swift"; sourceTree = "<group>"; };
 		A916AA5825F6F07100B7CEF2 /* DisplayGlucoseUnitObservable+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DisplayGlucoseUnitObservable+Preview.swift"; sourceTree = "<group>"; };
 		A91F7C93260524A0008FBAED /* CompleteDismissView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteDismissView.swift; sourceTree = "<group>"; };
@@ -155,6 +159,8 @@
 		A9502CF7260029A000146AD3 /* CheckmarkedBodyTextList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckmarkedBodyTextList.swift; sourceTree = "<group>"; };
 		A95422D225CC9A74003F3080 /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		A95BB9112603230B00E9FD17 /* Callout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Callout.swift; sourceTree = "<group>"; };
+		A95D623F2649FF410018B9EA /* AttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedString.swift; sourceTree = "<group>"; };
+		A95D624B264A006C0018B9EA /* Text+AttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+AttributedString.swift"; sourceTree = "<group>"; };
 		A967D848261FB121009D9675 /* NavigationBarAppearance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBarAppearance.swift; sourceTree = "<group>"; };
 		A98AD2B925830807001AAD6F /* TidepoolOnboardingPlugin.loopplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TidepoolOnboardingPlugin.loopplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		A98AD2BC25830807001AAD6F /* TidepoolOnboardingPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TidepoolOnboardingPlugin.h; sourceTree = "<group>"; };
@@ -257,6 +263,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A911C234264B283500EF3B85 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				A911C235264B284D00EF3B85 /* AttributedStringTests.swift */,
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
 		A91F7CED260528FD008FBAED /* TidepoolOnboardingDemo */ = {
 			isa = PBXGroup;
 			children = (
@@ -286,6 +300,7 @@
 				A923334025C3786100D8CF69 /* Environment+Complete.swift */,
 				A9BEF07B2588396F00860217 /* HKUnit.swift */,
 				A95422D225CC9A74003F3080 /* Image.swift */,
+				A95D624B264A006C0018B9EA /* Text+AttributedString.swift */,
 				A923333F25C3786100D8CF69 /* TimeInterval.swift */,
 				A9A80D842639DC6100770DA7 /* TPrescription.swift */,
 			);
@@ -384,6 +399,7 @@
 				A98AD2F825830851001AAD6F /* Info.plist */,
 				A99D0E2725FC971700CFFEA3 /* TidepoolOnboardingTests.swift */,
 				A99D0E1225FC8FB800CFFEA3 /* Mocks */,
+				A911C234264B283500EF3B85 /* Support */,
 				A99D0E0325FC8F2E00CFFEA3 /* View Models */,
 			);
 			path = TidepoolOnboardingTests;
@@ -504,6 +520,7 @@
 		A9D0401B25E43BDD00200E4E /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				A95D623F2649FF410018B9EA /* AttributedString.swift */,
 				A903C79725F1443200C88786 /* OnboardingSection.swift */,
 			);
 			path = Support;
@@ -847,6 +864,7 @@
 				A9B6736825F159A400D27872 /* YourDevicesViews.swift in Sources */,
 				A98AD31B25830887001AAD6F /* OSLog.swift in Sources */,
 				A90634562643426900CAFED1 /* OnboardingSectionWrapperView.swift in Sources */,
+				A95D62402649FF410018B9EA /* AttributedString.swift in Sources */,
 				A9502CBE25FFEF7B00146AD3 /* PageHeader.swift in Sources */,
 				A9A5739F2603AA080084592C /* WarningIcon.swift in Sources */,
 				A98AD30E25830879001AAD6F /* LocalizedString.swift in Sources */,
@@ -857,6 +875,7 @@
 				A9A90F92260A50FD00264BCB /* Paragraph.swift in Sources */,
 				A9EFBD322602D09B0070E9CC /* ModalPresentation.swift in Sources */,
 				A9E56C32262E1C4600A10627 /* NumberedBodyTextList.swift in Sources */,
+				A95D624C264A006D0018B9EA /* Text+AttributedString.swift in Sources */,
 				A923336525C3789800D8CF69 /* ActionButton.swift in Sources */,
 				A933F362260975A400DB84B9 /* AccessibleImage.swift in Sources */,
 				A9A0E46125C4FC3300C2D63F /* OnboardingRootNavigationController.swift in Sources */,
@@ -874,6 +893,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A911C236264B284D00EF3B85 /* AttributedStringTests.swift in Sources */,
 				A99D0E0525FC8F6F00CFFEA3 /* OnboardingViewModelTests.swift in Sources */,
 				A99D0E1425FC8FDA00CFFEA3 /* MockOnboardingProvider.swift in Sources */,
 				A99D0E2825FC971700CFFEA3 /* TidepoolOnboardingTests.swift in Sources */,

--- a/TidepoolOnboarding.xcodeproj/project.pbxproj
+++ b/TidepoolOnboarding.xcodeproj/project.pbxproj
@@ -24,9 +24,11 @@
 		A903C79825F1443200C88786 /* OnboardingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A903C79725F1443200C88786 /* OnboardingSection.swift */; };
 		A903C7A025F1444300C88786 /* OnboardingSectionNavigationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A903C79F25F1444300C88786 /* OnboardingSectionNavigationButton.swift */; };
 		A903C7A825F1444F00C88786 /* GettingToKnowTidepoolLoopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A903C7A725F1444F00C88786 /* GettingToKnowTidepoolLoopView.swift */; };
-		A906344A26433B9300CAFED1 /* TidepoolServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A906344926433B9300CAFED1 /* TidepoolServiceView.swift */; };
+		A906344A26433B9300CAFED1 /* ServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A906344926433B9300CAFED1 /* ServiceView.swift */; };
 		A90634562643426900CAFED1 /* OnboardingSectionWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90634552643426900CAFED1 /* OnboardingSectionWrapperView.swift */; };
 		A90E9F8826057CAF00566ED4 /* DemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90E9F8726057CAF00566ED4 /* DemoView.swift */; };
+		A911C20E264AEA3B00EF3B85 /* TProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A911C20D264AEA3B00EF3B85 /* TProfile.swift */; };
+		A911C224264B0FB200EF3B85 /* OnboardingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A911C223264B0FB200EF3B85 /* OnboardingError.swift */; };
 		A911C236264B284D00EF3B85 /* AttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A911C235264B284D00EF3B85 /* AttributedStringTests.swift */; };
 		A916AA5125F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A916AA5025F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift */; };
 		A916AA5925F6F07100B7CEF2 /* DisplayGlucoseUnitObservable+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A916AA5825F6F07100B7CEF2 /* DisplayGlucoseUnitObservable+Preview.swift */; };
@@ -57,6 +59,8 @@
 		A95BB9122603230B00E9FD17 /* Callout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95BB9112603230B00E9FD17 /* Callout.swift */; };
 		A95D62402649FF410018B9EA /* AttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95D623F2649FF410018B9EA /* AttributedString.swift */; };
 		A95D624C264A006D0018B9EA /* Text+AttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95D624B264A006C0018B9EA /* Text+AttributedString.swift */; };
+		A95D625D264A0F330018B9EA /* CGMManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95D625C264A0F330018B9EA /* CGMManagerView.swift */; };
+		A95D6264264A0F3C0018B9EA /* PumpManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95D6263264A0F3C0018B9EA /* PumpManagerView.swift */; };
 		A967D849261FB121009D9675 /* NavigationBarAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A967D848261FB121009D9675 /* NavigationBarAppearance.swift */; };
 		A98AD2BE25830807001AAD6F /* TidepoolOnboardingPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = A98AD2BC25830807001AAD6F /* TidepoolOnboardingPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A98AD2F225830851001AAD6F /* TidepoolOnboarding.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A98AD2E925830851001AAD6F /* TidepoolOnboarding.framework */; };
@@ -129,9 +133,11 @@
 		A903C79725F1443200C88786 /* OnboardingSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSection.swift; sourceTree = "<group>"; };
 		A903C79F25F1444300C88786 /* OnboardingSectionNavigationButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSectionNavigationButton.swift; sourceTree = "<group>"; };
 		A903C7A725F1444F00C88786 /* GettingToKnowTidepoolLoopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GettingToKnowTidepoolLoopView.swift; sourceTree = "<group>"; };
-		A906344926433B9300CAFED1 /* TidepoolServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolServiceView.swift; sourceTree = "<group>"; };
+		A906344926433B9300CAFED1 /* ServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceView.swift; sourceTree = "<group>"; };
 		A90634552643426900CAFED1 /* OnboardingSectionWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSectionWrapperView.swift; sourceTree = "<group>"; };
 		A90E9F8726057CAF00566ED4 /* DemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoView.swift; sourceTree = "<group>"; };
+		A911C20D264AEA3B00EF3B85 /* TProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TProfile.swift; sourceTree = "<group>"; };
+		A911C223264B0FB200EF3B85 /* OnboardingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingError.swift; sourceTree = "<group>"; };
 		A911C235264B284D00EF3B85 /* AttributedStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedStringTests.swift; sourceTree = "<group>"; };
 		A916AA5025F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingViewModel+Preview.swift"; sourceTree = "<group>"; };
 		A916AA5825F6F07100B7CEF2 /* DisplayGlucoseUnitObservable+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DisplayGlucoseUnitObservable+Preview.swift"; sourceTree = "<group>"; };
@@ -161,6 +167,8 @@
 		A95BB9112603230B00E9FD17 /* Callout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Callout.swift; sourceTree = "<group>"; };
 		A95D623F2649FF410018B9EA /* AttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedString.swift; sourceTree = "<group>"; };
 		A95D624B264A006C0018B9EA /* Text+AttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+AttributedString.swift"; sourceTree = "<group>"; };
+		A95D625C264A0F330018B9EA /* CGMManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGMManagerView.swift; sourceTree = "<group>"; };
+		A95D6263264A0F3C0018B9EA /* PumpManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpManagerView.swift; sourceTree = "<group>"; };
 		A967D848261FB121009D9675 /* NavigationBarAppearance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBarAppearance.swift; sourceTree = "<group>"; };
 		A98AD2B925830807001AAD6F /* TidepoolOnboardingPlugin.loopplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TidepoolOnboardingPlugin.loopplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		A98AD2BC25830807001AAD6F /* TidepoolOnboardingPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TidepoolOnboardingPlugin.h; sourceTree = "<group>"; };
@@ -303,6 +311,7 @@
 				A95D624B264A006C0018B9EA /* Text+AttributedString.swift */,
 				A923333F25C3786100D8CF69 /* TimeInterval.swift */,
 				A9A80D842639DC6100770DA7 /* TPrescription.swift */,
+				A911C20D264AEA3B00EF3B85 /* TProfile.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -497,12 +506,14 @@
 		A9BEF0352588359600860217 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				A95D625C264A0F330018B9EA /* CGMManagerView.swift */,
 				A903C7A725F1444F00C88786 /* GettingToKnowTidepoolLoopView.swift */,
 				A903C79F25F1444300C88786 /* OnboardingSectionNavigationButton.swift */,
 				A9502CB525FFEE8E00146AD3 /* OnboardingSectionPageView.swift */,
 				A9EBBD3C25F984560064804A /* OnboardingSectionSheetButton.swift */,
 				A90634552643426900CAFED1 /* OnboardingSectionWrapperView.swift */,
-				A906344926433B9300CAFED1 /* TidepoolServiceView.swift */,
+				A95D6263264A0F3C0018B9EA /* PumpManagerView.swift */,
+				A906344926433B9300CAFED1 /* ServiceView.swift */,
 				A923335325C3789700D8CF69 /* Accessory */,
 				A9B6733A25F158AF00D27872 /* Sections */,
 			);
@@ -521,6 +532,7 @@
 			isa = PBXGroup;
 			children = (
 				A95D623F2649FF410018B9EA /* AttributedString.swift */,
+				A911C223264B0FB200EF3B85 /* OnboardingError.swift */,
 				A903C79725F1443200C88786 /* OnboardingSection.swift */,
 			);
 			path = Support;
@@ -838,6 +850,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A95D6264264A0F3C0018B9EA /* PumpManagerView.swift in Sources */,
 				A933F31D260925EA00DB84B9 /* LoopIcon.swift in Sources */,
 				A99EAAA325F7FD1F00503A6D /* YourSettingsViews.swift in Sources */,
 				A933F3142608EFF500DB84B9 /* Segment.swift in Sources */,
@@ -852,7 +865,7 @@
 				A923334225C3786100D8CF69 /* Environment+Complete.swift in Sources */,
 				A916AA5125F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift in Sources */,
 				A93D2B112602606E0091FB65 /* AlertOnLongPressGesture.swift in Sources */,
-				A906344A26433B9300CAFED1 /* TidepoolServiceView.swift in Sources */,
+				A906344A26433B9300CAFED1 /* ServiceView.swift in Sources */,
 				A9A80D852639DC6100770DA7 /* TPrescription.swift in Sources */,
 				A9EBBD3D25F984560064804A /* OnboardingSectionSheetButton.swift in Sources */,
 				A9502CB625FFEE8E00146AD3 /* OnboardingSectionPageView.swift in Sources */,
@@ -866,8 +879,11 @@
 				A90634562643426900CAFED1 /* OnboardingSectionWrapperView.swift in Sources */,
 				A95D62402649FF410018B9EA /* AttributedString.swift in Sources */,
 				A9502CBE25FFEF7B00146AD3 /* PageHeader.swift in Sources */,
+				A95D625D264A0F330018B9EA /* CGMManagerView.swift in Sources */,
+				A911C20E264AEA3B00EF3B85 /* TProfile.swift in Sources */,
 				A9A5739F2603AA080084592C /* WarningIcon.swift in Sources */,
 				A98AD30E25830879001AAD6F /* LocalizedString.swift in Sources */,
+				A911C224264B0FB200EF3B85 /* OnboardingError.swift in Sources */,
 				A923336725C3789800D8CF69 /* ContentPreview.swift in Sources */,
 				A903C79825F1443200C88786 /* OnboardingSection.swift in Sources */,
 				A9502CCC25FFEFD500146AD3 /* PresentableImage.swift in Sources */,

--- a/TidepoolOnboarding/Extensions/TPrescription.swift
+++ b/TidepoolOnboarding/Extensions/TPrescription.swift
@@ -46,29 +46,29 @@ extension TPrescription {
         let initialSettings = TPrescription.InitialSettings(bloodGlucoseUnits: .milligramsPerDeciliter,
                                                             basalRateSchedule: [
                                                                 TPrescription.BasalRateStart(start: 0, rate: 1.0),
-                                                                TPrescription.BasalRateStart(start: 360000, rate: 1.5),
-                                                                TPrescription.BasalRateStart(start: 1080000, rate: 1.25)
+                                                                TPrescription.BasalRateStart(start: 21600000, rate: 1.5),
+                                                                TPrescription.BasalRateStart(start: 64800000, rate: 1.25)
                                                             ],
                                                             bloodGlucoseTargetPhysicalActivity: TPrescription.BloodGlucoseTarget(low: 150, high: 160),
                                                             bloodGlucoseTargetPreprandial: TPrescription.BloodGlucoseTarget(low: 80, high: 90),
                                                             bloodGlucoseTargetSchedule: [
-                                                                TPrescription.BloodGlucoseStartTarget(start: 0, low: 110, high: 120),
-                                                                TPrescription.BloodGlucoseStartTarget(start: 360000, low: 100, high: 110),
-                                                                TPrescription.BloodGlucoseStartTarget(start: 1320000, low: 110, high: 120),
+                                                                TPrescription.BloodGlucoseStartTarget(start: 0, low: 105, high: 115),
+                                                                TPrescription.BloodGlucoseStartTarget(start: 21600000, low: 100, high: 110),
+                                                                TPrescription.BloodGlucoseStartTarget(start: 79200000, low: 105, high: 115),
                                                             ],
                                                             carbohydrateRatioSchedule: [
                                                                 TPrescription.CarbohydrateRatioStart(start: 0, amount: 15),
-                                                                TPrescription.CarbohydrateRatioStart(start: 360000, amount: 12),
-                                                                TPrescription.CarbohydrateRatioStart(start: 720000, amount: 15)
+                                                                TPrescription.CarbohydrateRatioStart(start: 21600000, amount: 12),
+                                                                TPrescription.CarbohydrateRatioStart(start: 43200000, amount: 15)
                                                             ],
                                                             glucoseSafetyLimit: 80,
                                                             insulinModel: .rapidChild,
                                                             insulinSensitivitySchedule: [
                                                                 TPrescription.InsulinSensitivityStart(start: 0, amount: 55.0),
-                                                                TPrescription.InsulinSensitivityStart(start: 360000, amount: 45.0),
-                                                                TPrescription.InsulinSensitivityStart(start: 1320000, amount: 55.0),
+                                                                TPrescription.InsulinSensitivityStart(start: 21600000, amount: 45.0),
+                                                                TPrescription.InsulinSensitivityStart(start: 79200000, amount: 55.0),
                                                             ],
-                                                            basalRateMaximum: TPrescription.BasalRateMaximum(2.5, .unitsPerHour),
+                                                            basalRateMaximum: TPrescription.BasalRateMaximum(4.5, .unitsPerHour),
                                                             bolusAmountMaximum: TPrescription.BolusAmountMaximum(10, .units),
                                                             pumpId: "6678c377-928c-49b3-84c1-19e2dafaff8d",
                                                             cgmId: "d25c3f1b-a2e8-44e2-b3a3-fd07806fc245")

--- a/TidepoolOnboarding/Extensions/TProfile.swift
+++ b/TidepoolOnboarding/Extensions/TProfile.swift
@@ -1,0 +1,15 @@
+//
+//  TProfile.swift
+//  TidepoolOnboarding
+//
+//  Created by Darin Krauss on 5/11/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import TidepoolKit
+
+extension TProfile {
+    static var mock: TProfile {
+        return TProfile(fullName: "Mock Name")
+    }
+}

--- a/TidepoolOnboarding/Extensions/Text+AttributedString.swift
+++ b/TidepoolOnboarding/Extensions/Text+AttributedString.swift
@@ -1,0 +1,26 @@
+//
+//  Text+AttributedString.swift
+//  TidepoolOnboarding
+//
+//  Created by Darin Krauss on 5/10/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import SwiftUI
+
+extension Text {
+    init(_ attributedString: AttributedString) {
+        self = attributedString.fragments.reduce(Text("")) { $0 + Text($1) }
+    }
+
+    init(_ fragment: AttributedString.Fragment) {
+        var text = Text(fragment.string)
+        if fragment.attributes?.contains(.bold) == true {
+            text = text.bold()
+        }
+        if fragment.attributes?.contains(.italic) == true {
+            text = text.italic()
+        }
+        self = text
+    }
+}

--- a/TidepoolOnboarding/Support/AttributedString.swift
+++ b/TidepoolOnboarding/Support/AttributedString.swift
@@ -59,7 +59,7 @@ struct AttributedString {
             switch elementName {
             case "b":
                 attributes.append(.bold)
-            case "em":
+            case "em", "i":
                 attributes.append(.italic)
             default:
                 break
@@ -68,7 +68,7 @@ struct AttributedString {
 
         func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
             switch elementName {
-            case "b", "em":
+            case "b", "em", "i":
                 _ = attributes.popLast()
             default:
                 break

--- a/TidepoolOnboarding/Support/AttributedString.swift
+++ b/TidepoolOnboarding/Support/AttributedString.swift
@@ -1,0 +1,103 @@
+//
+//  AttributedString.swift
+//  TidepoolOnboarding
+//
+//  Created by Darin Krauss on 5/10/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+struct AttributedString {
+    enum Attribute {
+        case bold
+        case italic
+    }
+
+    struct Fragment {
+        let string: String
+        let attributes: Set<Attribute>?
+
+        init(_ string: String, attributes: Set<Attribute>? = nil) {
+            self.string = string
+            self.attributes = attributes?.isEmpty == false ? attributes : nil
+        }
+    }
+
+    let fragments: [Fragment]
+
+    init(_ string: String) {
+        self.fragments = [Fragment(string)]
+    }
+
+    init(attributed string: String) {
+        self.fragments = Parser().parse(string) ?? [Fragment(string)]
+    }
+
+    var string: String { fragments.reduce(String(), { $0 + $1.string }) }
+
+    private class Parser: NSObject, XMLParserDelegate {
+        private var fragments: [Fragment] = []
+        private var attributes: [Attribute] = []
+        private var error: Error?
+
+        func parse(_ string: String) -> [Fragment]? {
+            guard let data = "<normal>\(string)</normal>".data(using: .utf8) else {
+                return nil
+            }
+
+            let parser = XMLParser(data: data)
+            parser.delegate = self
+            guard parser.parse() else {
+                return nil
+            }
+
+            return !fragments.isEmpty ? fragments : nil
+        }
+
+        func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String: String] = [:]) {
+            switch elementName {
+            case "b":
+                attributes.append(.bold)
+            case "em":
+                attributes.append(.italic)
+            default:
+                break
+            }
+        }
+
+        func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
+            switch elementName {
+            case "b", "em":
+                _ = attributes.popLast()
+            default:
+                break
+            }
+
+        }
+
+        func parser(_ parser: XMLParser, foundCharacters string: String) {
+            fragments.append(Fragment(string, attributes: Set<Attribute>(attributes)))
+        }
+    }
+}
+
+extension AttributedString {
+    private init(_ other: Self, applying attribute: Attribute) {
+        self.fragments = other.fragments.map { Fragment($0, applying: attribute) }
+    }
+
+    func bold() -> Self { Self(self, applying: .bold) }
+
+    func italic() -> Self { Self(self, applying: .italic) }
+}
+
+fileprivate extension AttributedString.Fragment {
+    init(_ other: Self, applying attribute: AttributedString.Attribute) {
+        var attributes = other.attributes ?? []
+        attributes.insert(attribute)
+
+        self.string = other.string
+        self.attributes = attributes
+    }
+}

--- a/TidepoolOnboarding/Support/OnboardingError.swift
+++ b/TidepoolOnboarding/Support/OnboardingError.swift
@@ -1,0 +1,27 @@
+//
+//  OnboardingError.swift
+//  TidepoolOnboarding
+//
+//  Created by Darin Krauss on 5/11/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+enum OnboardingError: LocalizedError {
+    case unexpectedState
+    case networkFailure
+    case authenticationFailure
+    case resourceNotFound
+
+    var errorDescription: String? {
+        switch self {
+        case .unexpectedState:
+            return LocalizedString("An unexpected state occurred.", comment: "Error description for an unexpected state.")
+        case .networkFailure:
+            return LocalizedString("Poor network connection detected. Please check your connectivity and try again.", comment: "Error description for a network failure.")
+        case .authenticationFailure:
+            return LocalizedString("An authentication error occurred.", comment: "Error description for an authentication failure.")
+        case .resourceNotFound:
+            return LocalizedString("A network error occurred.", comment: "Error description for a resource not found.")
+        }
+    }
+}

--- a/TidepoolOnboarding/TidepoolOnboarding.swift
+++ b/TidepoolOnboarding/TidepoolOnboarding.swift
@@ -147,6 +147,7 @@ public final class TidepoolOnboarding: ObservableObject, OnboardingUI {
     public func reset() {
         self.dosingEnabled = nil
         self.therapySettings = nil
+        self.prescriberProfile = nil
         self.prescription = nil
         self.sectionProgression = OnboardingSectionProgression()
         self.lastAccessDate = Date()

--- a/TidepoolOnboarding/TidepoolOnboarding.swift
+++ b/TidepoolOnboarding/TidepoolOnboarding.swift
@@ -54,6 +54,30 @@ public final class TidepoolOnboarding: ObservableObject, OnboardingUI {
         }
     }
 
+    var notificationAuthorization: NotificationAuthorization? {
+        didSet {
+            notifyDidUpdateState()
+        }
+    }
+
+    var healthStoreAuthorization: HealthStoreAuthorization? {
+        didSet {
+            notifyDidUpdateState()
+        }
+    }
+
+    var cgmManagerIdentifier: String? {
+        didSet {
+            notifyDidUpdateState()
+        }
+    }
+
+    var pumpManagerIdentifier: String? {
+        didSet {
+            notifyDidUpdateState()
+        }
+    }
+
     var dosingEnabled: Bool? {
         didSet {
             notifyDidUpdateState()
@@ -86,6 +110,14 @@ public final class TidepoolOnboarding: ObservableObject, OnboardingUI {
         if let rawTherapySettings = rawState["therapySettings"] as? Data {
             self.therapySettings = try? Self.decoder.decode(TherapySettings.self, from: rawTherapySettings)
         }
+        if let rawNotificationAuthorization = rawState["notificationAuthorization"] as? Int {
+            self.notificationAuthorization = NotificationAuthorization(rawValue: rawNotificationAuthorization)
+        }
+        if let rawHealthStoreAuthorization = rawState["healthStoreAuthorization"] as? Int {
+            self.healthStoreAuthorization = HealthStoreAuthorization(rawValue: rawHealthStoreAuthorization)
+        }
+        self.cgmManagerIdentifier = rawState["cgmManagerIdentifier"] as? String
+        self.pumpManagerIdentifier = rawState["pumpManagerIdentifier"] as? String
         self.dosingEnabled = rawState["dosingEnabled"] as? Bool
 
         self.isOnboarded = sectionProgression.hasCompletedAllSections
@@ -106,6 +138,10 @@ public final class TidepoolOnboarding: ObservableObject, OnboardingUI {
         if let therapySettings = therapySettings {
             rawState["therapySettings"] = try? Self.encoder.encode(therapySettings)
         }
+        rawState["notificationAuthorization"] = notificationAuthorization?.rawValue
+        rawState["healthStoreAuthorization"] = healthStoreAuthorization?.rawValue
+        rawState["cgmManagerIdentifier"] = cgmManagerIdentifier
+        rawState["pumpManagerIdentifier"] = pumpManagerIdentifier
         rawState["dosingEnabled"] = dosingEnabled
 
         return rawState
@@ -146,6 +182,10 @@ public final class TidepoolOnboarding: ObservableObject, OnboardingUI {
 
     public func reset() {
         self.dosingEnabled = nil
+        self.pumpManagerIdentifier = nil
+        self.cgmManagerIdentifier = nil
+        self.healthStoreAuthorization = nil
+        self.notificationAuthorization = nil
         self.therapySettings = nil
         self.prescriberProfile = nil
         self.prescription = nil

--- a/TidepoolOnboarding/Views/Accessory/BodyText.swift
+++ b/TidepoolOnboarding/Views/Accessory/BodyText.swift
@@ -53,7 +53,7 @@ extension BodyText {
 
     func italic() -> Self { Self(self, isItalic: true) }
 
-    func foregroundColor(_ color: Color) -> Self { Self(self, foregroundColor: color) }
+    func foregroundColor(_ color: Color?) -> Self { Self(self, foregroundColor: color) }
 }
 
 struct BodyText_Previews: PreviewProvider {

--- a/TidepoolOnboarding/Views/Accessory/BodyText.swift
+++ b/TidepoolOnboarding/Views/Accessory/BodyText.swift
@@ -9,48 +9,43 @@
 import SwiftUI
 
 struct BodyText: View {
-    private let string: String
-    private let isBold: Bool
-    private let isItalic: Bool
+    private let attributedString: AttributedString
     private let foregroundColor: Color
 
+    init(_ attributedString: AttributedString) {
+        self.attributedString = attributedString
+        self.foregroundColor = .accentColor
+    }
+
     init(_ string: String) {
-        self.string = string
-        self.isBold = false
-        self.isItalic = false
+        self.attributedString = AttributedString(string)
+        self.foregroundColor = .accentColor
+    }
+
+    init(attributed string: String) {
+        self.attributedString = AttributedString(attributed: string)
         self.foregroundColor = .accentColor
     }
 
     var body: some View {
-        formattedText
+        Text(attributedString)
+            .font(.body)
             .accentColor(.secondary)
             .foregroundColor(foregroundColor)
-    }
-
-    @ViewBuilder
-    var formattedText: some View {
-        if isBold && isItalic {
-            bodyText.bold().italic()
-        } else if isBold {
-            bodyText.bold()
-        } else if isItalic {
-            bodyText.italic()
-        } else {
-            bodyText
-        }
-    }
-
-    var bodyText: Text {
-        Text(string)
-            .font(.body)
     }
 }
 
 extension BodyText {
     init(_ other: Self, isBold: Bool? = nil, isItalic: Bool? = nil, foregroundColor: Color? = nil) {
-        self.string = other.string
-        self.isBold = isBold ?? other.isBold
-        self.isItalic = isItalic ?? other.isItalic
+        var attributedString = other.attributedString
+        if isBold == true {
+            attributedString = attributedString.bold()
+        }
+        if isItalic == true {
+            attributedString = attributedString.italic()
+        }
+
+        self.attributedString = attributedString
         self.foregroundColor = foregroundColor ?? other.foregroundColor
     }
 

--- a/TidepoolOnboarding/Views/Accessory/BulletedBodyTextList.swift
+++ b/TidepoolOnboarding/Views/Accessory/BulletedBodyTextList.swift
@@ -28,7 +28,6 @@ struct BulletedBodyTextList: View {
             ForEach(attributedStrings.indices) { index in
                 HStack(spacing: 10) {
                     Bullet()
-                        .foregroundColor(.accentColor)
                     BodyText(attributedStrings[index])
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -36,15 +35,16 @@ struct BulletedBodyTextList: View {
         }
         .padding(.horizontal)
     }
+}
     
-    private struct Bullet: View {
-        @ScaledMetric var size: CGFloat = 8
-        
-        var body: some View {
-            Circle()
-                .frame(width: size, height: size)
-                .opacity(0.5)
-        }
+struct Bullet: View {
+    @ScaledMetric var size: CGFloat = 8
+
+    var body: some View {
+        Circle()
+            .frame(width: size, height: size)
+            .opacity(0.5)
+            .foregroundColor(.accentColor)
     }
 }
 

--- a/TidepoolOnboarding/Views/Accessory/BulletedBodyTextList.swift
+++ b/TidepoolOnboarding/Views/Accessory/BulletedBodyTextList.swift
@@ -9,23 +9,27 @@
 import SwiftUI
 
 struct BulletedBodyTextList: View {
-    private let strings: [String]
+    private let attributedStrings: [AttributedString]
 
-    init(_ strings: [String]) {
-        self.strings = strings
+    init(_ attributedStrings: AttributedString...) {
+        self.attributedStrings = attributedStrings
     }
     
     init(_ strings: String...) {
-        self.strings = strings
+        self.attributedStrings = strings.map { AttributedString($0) }
     }
     
+    init(attributed strings: String...) {
+        self.attributedStrings = strings.map { AttributedString(attributed: $0) }
+    }
+
     var body: some View {
         VStack(alignment: .leading) {
-            ForEach(strings.indices) { index in
+            ForEach(attributedStrings.indices) { index in
                 HStack(spacing: 10) {
                     Bullet()
                         .foregroundColor(.accentColor)
-                    BodyText(strings[index])
+                    BodyText(attributedStrings[index])
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }

--- a/TidepoolOnboarding/Views/Accessory/CheckmarkedBodyTextList.swift
+++ b/TidepoolOnboarding/Views/Accessory/CheckmarkedBodyTextList.swift
@@ -9,23 +9,27 @@
 import SwiftUI
 
 struct CheckmarkedBodyTextList: View {
-    private let strings: [String]
+    private let attributedStrings: [AttributedString]
 
-    init(_ strings: [String]) {
-        self.strings = strings
+    init(_ attributedStrings: AttributedString...) {
+        self.attributedStrings = attributedStrings
     }
     
     init(_ strings: String...) {
-        self.strings = strings
+        self.attributedStrings = strings.map { AttributedString($0) }
     }
     
+    init(attributed strings: String...) {
+        self.attributedStrings = strings.map { AttributedString(attributed: $0) }
+    }
+
     var body: some View {
         VStack(alignment: .leading) {
-            ForEach(strings.indices) { index in
+            ForEach(attributedStrings.indices) { index in
                 HStack(spacing: 10) {
                     Checkmark()
                         .foregroundColor(.accentColor)
-                    BodyText(strings[index])
+                    BodyText(attributedStrings[index])
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }

--- a/TidepoolOnboarding/Views/Accessory/CheckmarkedBodyTextList.swift
+++ b/TidepoolOnboarding/Views/Accessory/CheckmarkedBodyTextList.swift
@@ -27,23 +27,23 @@ struct CheckmarkedBodyTextList: View {
         VStack(alignment: .leading) {
             ForEach(attributedStrings.indices) { index in
                 HStack(spacing: 10) {
-                    Checkmark()
-                        .foregroundColor(.accentColor)
+                    CheckmarkCircle()
                     BodyText(attributedStrings[index])
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
     }
-    
-    private struct Checkmark: View {
-        @ScaledMetric var size: CGFloat = 22
-        
-        var body: some View {
-            Image(systemName: "checkmark.circle.fill")
-                .resizable()
-                .frame(width: size, height: size)
-        }
+}
+
+struct CheckmarkCircle: View {
+    @ScaledMetric var size: CGFloat = 22
+
+    var body: some View {
+        Image(systemName: "checkmark.circle.fill")
+            .resizable()
+            .foregroundColor(.accentColor)
+            .frame(width: size, height: size)
     }
 }
 

--- a/TidepoolOnboarding/Views/Accessory/NumberedBodyTextList.swift
+++ b/TidepoolOnboarding/Views/Accessory/NumberedBodyTextList.swift
@@ -31,8 +31,7 @@ struct NumberedBodyTextList: View {
         VStack(alignment: .leading) {
             ForEach(attributedStrings.indices) { index in
                 HStack(spacing: 10) {
-                    Number(startingAt + index)
-                        .foregroundColor(.accentColor)
+                    NumberCircle(startingAt + index)
                     BodyText(attributedStrings[index])
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -45,24 +44,25 @@ struct NumberedBodyTextList: View {
     private func accessibilityValue(for index: Int) -> String {
         String(format: LocalizedString("%d, %2$@", comment: "Accessibility value for numbered list item (1: item number)(2: item text)"), startingAt + index, attributedStrings[index].string)
     }
+}
 
-    private struct Number: View {
-        private let number: Int
+struct NumberCircle: View {
+    private let number: Int
 
-        @ScaledMetric var size: CGFloat = 21
+    @ScaledMetric var size: CGFloat = 21
 
-        init(_ number: Int) {
-            self.number = number
-        }
+    init(_ number: Int) {
+        self.number = number
+    }
 
-        var body: some View {
-            ZStack {
-                Circle()
-                    .frame(width: size, height: size)
-                Text("\(number)")
-                    .font(.footnote)
-                    .foregroundColor(.white)
-            }
+    var body: some View {
+        ZStack {
+            Circle()
+                .foregroundColor(.accentColor)
+                .frame(width: size, height: size)
+            Text("\(number)")
+                .font(.footnote)
+                .foregroundColor(.white)
         }
     }
 }
@@ -73,7 +73,7 @@ extension NumberedBodyTextList {
         self.startingAt = startingAt ?? other.startingAt
     }
 
-    func startingAt(_ startingAt: Int) -> Self { Self(self, startingAt: startingAt) }
+    func startingAt(_ startingAt: Int?) -> Self { Self(self, startingAt: startingAt) }
 }
 
 struct NumberedBodyTextList_Previews: PreviewProvider {

--- a/TidepoolOnboarding/Views/Accessory/NumberedBodyTextList.swift
+++ b/TidepoolOnboarding/Views/Accessory/NumberedBodyTextList.swift
@@ -9,26 +9,31 @@
 import SwiftUI
 
 struct NumberedBodyTextList: View {
-    private let strings: [String]
+    private let attributedStrings: [AttributedString]
     private let startingAt: Int
 
-    init(_ strings: [String]) {
-        self.strings = strings
+    init(_ attributedStrings: AttributedString...) {
+        self.attributedStrings = attributedStrings
         self.startingAt = 1
     }
 
     init(_ strings: String...) {
-        self.strings = strings
+        self.attributedStrings = strings.map { AttributedString($0) }
+        self.startingAt = 1
+    }
+
+    init(attributed strings: String...) {
+        self.attributedStrings = strings.map { AttributedString(attributed: $0) }
         self.startingAt = 1
     }
 
     var body: some View {
         VStack(alignment: .leading) {
-            ForEach(strings.indices) { index in
+            ForEach(attributedStrings.indices) { index in
                 HStack(spacing: 10) {
                     Number(startingAt + index)
                         .foregroundColor(.accentColor)
-                    BodyText(strings[index])
+                    BodyText(attributedStrings[index])
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 .accessibilityElement(children: .ignore)
@@ -38,7 +43,7 @@ struct NumberedBodyTextList: View {
     }
 
     private func accessibilityValue(for index: Int) -> String {
-        String(format: LocalizedString("%d, %2$@", comment: "Accessibility value for numbered list item (1: item number)(2: item text)"), startingAt + index, strings[index])
+        String(format: LocalizedString("%d, %2$@", comment: "Accessibility value for numbered list item (1: item number)(2: item text)"), startingAt + index, attributedStrings[index].string)
     }
 
     private struct Number: View {
@@ -64,7 +69,7 @@ struct NumberedBodyTextList: View {
 
 extension NumberedBodyTextList {
     init(_ other: Self, startingAt: Int? = nil) {
-        self.strings = other.strings
+        self.attributedStrings = other.attributedStrings
         self.startingAt = startingAt ?? other.startingAt
     }
 

--- a/TidepoolOnboarding/Views/Accessory/PageHeader.swift
+++ b/TidepoolOnboarding/Views/Accessory/PageHeader.swift
@@ -48,7 +48,7 @@ extension PageHeader {
         self.dividerHidden = dividerHidden ?? other.dividerHidden
     }
 
-    func dividerHidden(_ dividerHidden: Bool) -> Self { Self(self, dividerHidden: dividerHidden) }
+    func dividerHidden(_ dividerHidden: Bool?) -> Self { Self(self, dividerHidden: dividerHidden) }
 }
 
 struct PageHeader_Previews: PreviewProvider {

--- a/TidepoolOnboarding/Views/Accessory/Segment.swift
+++ b/TidepoolOnboarding/Views/Accessory/Segment.swift
@@ -50,7 +50,7 @@ extension Segment {
         self.content = other.content
     }
 
-    func headerFont(_ headerFont: Font) -> Self { Self(self, headerFont: headerFont) }
+    func headerFont(_ headerFont: Font?) -> Self { Self(self, headerFont: headerFont) }
 
-    func headerSpacing(_ headerSpacing: CGFloat) -> Self { Self(self, headerSpacing: headerSpacing) }
+    func headerSpacing(_ headerSpacing: CGFloat?) -> Self { Self(self, headerSpacing: headerSpacing) }
 }

--- a/TidepoolOnboarding/Views/CGMManagerView.swift
+++ b/TidepoolOnboarding/Views/CGMManagerView.swift
@@ -1,28 +1,28 @@
 //
-//  TidepoolServiceView.swift
+//  CGMManagerView.swift
 //  TidepoolOnboarding
 //
-//  Created by Darin Krauss on 5/5/21.
+//  Created by Darin Krauss on 5/10/21.
 //  Copyright © 2021 Tidepool Project. All rights reserved.
 //
 
 import SwiftUI
 import LoopKitUI
 
-struct TidepoolServiceView: UIViewControllerRepresentable {
+struct CGMManagerView: UIViewControllerRepresentable {
     @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     @Environment(\.dismiss) var dismiss
 
-    private let serviceViewController: ServiceViewController
+    private let cgmManagerViewController: CGMManagerViewController
 
-    init(_ serviceViewController: ServiceViewController) {
-        self.serviceViewController = serviceViewController
+    init(_ cgmManagerViewController: CGMManagerViewController) {
+        self.cgmManagerViewController = cgmManagerViewController
     }
 
     final class Coordinator: CompletionDelegate {
-        private let parent: TidepoolServiceView
+        private let parent: CGMManagerView
 
-        init(_ parent: TidepoolServiceView) {
+        init(_ parent: CGMManagerView) {
             self.parent = parent
         }
 
@@ -32,10 +32,10 @@ struct TidepoolServiceView: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Context) -> UIViewController {
-        var serviceViewController = self.serviceViewController
-        serviceViewController.serviceOnboardingDelegate = onboardingViewModel
-        serviceViewController.completionDelegate = context.coordinator
-        return serviceViewController
+        var cgmManagerViewController = self.cgmManagerViewController
+        cgmManagerViewController.cgmManagerOnboardingDelegate = onboardingViewModel
+        cgmManagerViewController.completionDelegate = context.coordinator
+        return cgmManagerViewController
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}

--- a/TidepoolOnboarding/Views/GettingToKnowTidepoolLoopView.swift
+++ b/TidepoolOnboarding/Views/GettingToKnowTidepoolLoopView.swift
@@ -40,10 +40,7 @@ struct GettingToKnowTidepoolLoopView: View {
     }
 
     private var description: some View {
-        Text(LocalizedString("You can take your time through each section. The app will save your place and start you back at the beginning of a section if you step away.", comment: "Onboarding, Getting to Know Tidepool Loop summary, body"))
-            .font(.body)
-            .accentColor(.secondary)
-            .foregroundColor(.accentColor)
+        BodyText(LocalizedString("You can take your time through each section. The app will save your place and start you back at the beginning of a section if you step away.", comment: "Onboarding, Getting to Know Tidepool Loop summary, body"))
     }
 
     private var buttons: some View {

--- a/TidepoolOnboarding/Views/OnboardingSectionWrapperView.swift
+++ b/TidepoolOnboarding/Views/OnboardingSectionWrapperView.swift
@@ -107,9 +107,9 @@ extension OnboardingSectionWrapperView {
         self.content = other.content
     }
 
-    func editMode(_ editMode: Bool) -> Self { Self(self, editMode: editMode) }
+    func editMode(_ editMode: Bool?) -> Self { Self(self, editMode: editMode) }
 
-    func backButtonHidden(_ backButtonHidden: Bool) -> Self { Self(self, backButtonHidden: backButtonHidden) }
+    func backButtonHidden(_ backButtonHidden: Bool?) -> Self { Self(self, backButtonHidden: backButtonHidden) }
 
-    func closeButtonHidden(_ closeButtonHidden: Bool) -> Self { Self(self, closeButtonHidden: closeButtonHidden) }
+    func closeButtonHidden(_ closeButtonHidden: Bool?) -> Self { Self(self, closeButtonHidden: closeButtonHidden) }
 }

--- a/TidepoolOnboarding/Views/PumpManagerView.swift
+++ b/TidepoolOnboarding/Views/PumpManagerView.swift
@@ -1,0 +1,44 @@
+//
+//  PumpManagerView.swift
+//  TidepoolOnboarding
+//
+//  Created by Darin Krauss on 5/10/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import SwiftUI
+import LoopKitUI
+
+struct PumpManagerView: UIViewControllerRepresentable {
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+    @Environment(\.dismiss) var dismiss
+
+    private let pumpManagerViewController: PumpManagerViewController
+
+    init(_ pumpManagerViewController: PumpManagerViewController) {
+        self.pumpManagerViewController = pumpManagerViewController
+    }
+
+    final class Coordinator: CompletionDelegate {
+        private let parent: PumpManagerView
+
+        init(_ parent: PumpManagerView) {
+            self.parent = parent
+        }
+
+        func completionNotifyingDidComplete(_ object: CompletionNotifying) {
+            parent.dismiss()
+        }
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        var pumpManagerViewController = self.pumpManagerViewController
+        pumpManagerViewController.pumpManagerOnboardingDelegate = onboardingViewModel
+        pumpManagerViewController.completionDelegate = context.coordinator
+        return pumpManagerViewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+}

--- a/TidepoolOnboarding/Views/Sections/ADayInTheLifeViews.swift
+++ b/TidepoolOnboarding/Views/Sections/ADayInTheLifeViews.swift
@@ -341,7 +341,7 @@ fileprivate struct ADayInTheLifeView25: View {
             PageHeader(title: LocalizedString("Checkpoint", comment: "Onboarding, A Day In The Life section, view 25, title"))
             CheckpointCheckmark()
             Paragraph(LocalizedString("You’ve seen how you might use Tidepool Loop in daily life for:", comment: "Onboarding, A Day In The Life section, view 25, paragraph 1"))
-            BulletedBodyTextList(
+            CheckmarkedBodyTextList(
                 LocalizedString("Eating", comment: "Onboarding, A Day In The Life section, view 25, list, item 1"),
                 LocalizedString("Sleeping", comment: "Onboarding, A Day In The Life section, view 25, list, item 2"),
                 LocalizedString("Exercising", comment: "Onboarding, A Day In The Life section, view 25, list, item 3"),

--- a/TidepoolOnboarding/Views/Sections/GetLoopingViews.swift
+++ b/TidepoolOnboarding/Views/Sections/GetLoopingViews.swift
@@ -63,7 +63,7 @@ fileprivate struct GetLoopingView2: View {
         OnboardingSectionPageView(section: .getLooping, destination: GetLoopingView3()) {
             PageHeader(title: LocalizedString("Select Loop Mode", comment: "Onboarding, Get Looping section, view 2, title"))
                 .dividerHidden(true)
-            if onboardingViewModel.dosingEnabled {
+            if onboardingViewModel.dosingEnabled == true {
                 Paragraph(LocalizedString("Closed Loop is now set to ON.", comment: "Onboarding, Get Looping section, view 2, paragraph 1, closed loop on"))
             } else {
                 Paragraph(LocalizedString("Closed Loop is now set to OFF.", comment: "Onboarding, Get Looping section, view 2, paragraph 1, closed loop off"))
@@ -76,6 +76,11 @@ fileprivate struct GetLoopingView2: View {
         }
         .editMode(true)
         .alert(isPresented: $isOffAlertPresented) { offAlert }
+        .onAppear {
+            if onboardingViewModel.dosingEnabled == nil {
+                onboardingViewModel.dosingEnabled = true
+            }
+        }
     }
 
     private var toggle: some View {
@@ -87,10 +92,10 @@ fileprivate struct GetLoopingView2: View {
     
     private var isClosedLoopOn: Binding<Bool> {
         Binding(
-            get: { onboardingViewModel.dosingEnabled },
+            get: { onboardingViewModel.dosingEnabled ?? false },
             set: {
                 onboardingViewModel.dosingEnabled = $0
-                if !onboardingViewModel.dosingEnabled {
+                if !$0 {
                     isOffAlertPresented = true
                 }
             }

--- a/TidepoolOnboarding/Views/Sections/YourDevicesViews.swift
+++ b/TidepoolOnboarding/Views/Sections/YourDevicesViews.swift
@@ -10,30 +10,43 @@ import SwiftUI
 import LoopKitUI
 
 struct YourDevicesNavigationButton: View {
-    var body: some View {
-        OnboardingSectionNavigationButton(section: .yourDevices, destination: NavigationViewWithNavigationBarAppearance { YourDevicesViewNotifications() })
-            .accessibilityIdentifier("button_your_devices")
-    }
-}
-
-fileprivate struct YourDevicesViewNotifications: View {
     @EnvironmentObject var onboardingViewModel: OnboardingViewModel
 
     var body: some View {
-        OnboardingSectionPageView(section: .yourDevices) {
-            PageHeader(title: LocalizedString("Notifications", comment: "Onboarding, Your Devices section, notifications, title"))
-            Paragraph(LocalizedString("To allow your CGM, pump, and Tidepool Loop app to alert you with important safety and maintenance notifications, you’ll next need to:", comment: "Onboarding, Your Devices section, notifications, paragraph 1"))
+        OnboardingSectionNavigationButton(section: .yourDevices, destination: NavigationViewWithNavigationBarAppearance { destination })
+            .accessibilityIdentifier("button_your_devices")
+    }
+
+    @ViewBuilder
+    private var destination: some View {
+        if onboardingViewModel.notificationAuthorization == nil || onboardingViewModel.notificationAuthorization == .notDetermined {
+            YourDevicesNotificationsView()
+        } else if !onboardingViewModel.isCGMManagerOnboarded || !onboardingViewModel.isPumpManagerOnboarded {
+            YourDevicesPairingYourDevicesView()
+        }
+    }
+}
+
+// MARK: - YourDevicesNotificationsView
+
+fileprivate struct YourDevicesNotificationsView: View {
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+
+    var body: some View {
+        OnboardingSectionPageView(section: .yourDevices, destination: YourDevicesPairingYourDevicesView()) {
+            PageHeader(title: LocalizedString("Notifications", comment: "Onboarding, Your Devices section, Notifications view, title"))
+            Paragraph(LocalizedString("To allow your CGM, pump, and Tidepool Loop app to alert you with important safety and maintenance notifications, you’ll next need to:", comment: "Onboarding, Your Devices section, Notifications view, paragraph 1"))
             NumberedBodyTextList(
-                LocalizedString("Enable Notifications in your iPhone or iPod Touch Settings", comment: "Onboarding, Your Devices section, notifications, list 1, item 1")
+                LocalizedString("Enable Notifications in your iPhone or iPod Touch Settings", comment: "Onboarding, Your Devices section, Notifications view, list 1, item 1")
             )
             .padding(.vertical)
-            Paragraph(LocalizedString("Notifications may be configured for each component you pair, and can alert you to rising and falling glucose, insulin pump maintenance tasks, or other situations where the app may need your attention.", comment: "Onboarding, Your Devices section, notifications, paragraph 2"))
+            Paragraph(LocalizedString("Notifications may be configured for each component you pair, and can alert you to rising and falling glucose, insulin pump maintenance tasks, or other situations where the app may need your attention.", comment: "Onboarding, Your Devices section, Notifications view, paragraph 2"))
             NumberedBodyTextList(
-                LocalizedString("Enable Critical Alerts in your iPhone or iPod Touch Settings", comment: "Onboarding, Your Devices section, notifications, list 2, item 1")
+                LocalizedString("Enable Critical Alerts in your iPhone or iPod Touch Settings", comment: "Onboarding, Your Devices section, Notifications view, list 2, item 1")
             )
             .startingAt(2)
             .padding(.vertical)
-            Paragraph(LocalizedString("Critical Alerts may be configured to alert you to higher risk situations while using Tidepool Loop, such as urgent low glucose, insulin pump occlusions, or other serious system errors.", comment: "Onboarding, Your Devices section, notifications, paragraph 3"))
+            Paragraph(LocalizedString("Critical Alerts may be configured to alert you to higher risk situations while using Tidepool Loop, such as urgent low glucose, insulin pump occlusions, or other serious system errors.", comment: "Onboarding, Your Devices section, Notifications view, paragraph 3"))
         }
         .backButtonHidden(true)
         .nextButtonAction(nextButtonAction)
@@ -41,7 +54,160 @@ fileprivate struct YourDevicesViewNotifications: View {
 
     private func nextButtonAction(_ completion: @escaping (Bool) -> Void) {
         onboardingViewModel.onboardingProvider.authorizeNotification { authorization in
-            completion(authorization != .notDetermined)
+            DispatchQueue.main.async {
+                onboardingViewModel.notificationAuthorization = authorization
+                completion(authorization != .notDetermined)
+            }
+        }
+    }
+}
+
+// MARK: - YourDevicesPairingYourDevicesView
+
+fileprivate struct YourDevicesPairingYourDevicesView: View {
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+
+    @State private var alertMessage: String?
+    @State private var isAlertPresented = false
+
+    @State private var isCGMManagerOnboarded = false
+    @State private var cgmManagerViewController: CGMManagerViewController?
+    @State private var isPumpManagerOnboarded = false
+    @State private var pumpManagerViewController: PumpManagerViewController?
+    @State private var isSheetPresented = false
+    @State private var onSheetDismiss: (() -> Void)?
+
+    var body: some View {
+        OnboardingSectionPageView(section: .yourDevices) {
+            PageHeader(title: LocalizedString("Pairing Your Devices", comment: "Onboarding, Your Devices section, Pairing Your Devices view, title"))
+            Paragraph(LocalizedString("Use your product instructions along with this app to help you pair your devices.", comment: "Onboarding, Your Devices section, Pairing Your Devices view, paragraph 1"))
+            Paragraph(LocalizedString("Before pairing your devices, make sure your smart device, on which you are reading this screen, is connected to the internet.", comment: "Onboarding, Your Devices section, Pairing Your Devices view, paragraph 2"))
+            Paragraph(LocalizedString("You must have both CGM and Pump with you to proceed.", comment: "Onboarding, Your Devices section, Pairing Your Devices view, paragraph 3"))
+                .bold()
+            Paragraph(LocalizedString("If you do not yet have both devices, you should wait until you do to proceed.", comment: "Onboarding, Your Devices section, Pairing Your Devices view, paragraph 4"))
+            VStack(alignment: .leading, spacing: 30) {
+                DeviceView(number: 1, attributed: cgmManagerText, checked: isCGMManagerOnboarded)
+                DeviceView(number: 2, attributed: pumpManagerText, checked: isPumpManagerOnboarded)
+            }
+            .padding(.vertical)
+        }
+        .backButtonHidden(true)
+        .nextButtonTitle(nextButtonTitle)
+        .nextButtonAction(nextButtonAction)
+        .alert(isPresented: $isAlertPresented) { alert }
+        .sheet(isPresented: $isSheetPresented, onDismiss: onSheetDismiss) { sheet }
+        .onAppear {
+            isCGMManagerOnboarded = onboardingViewModel.isCGMManagerOnboarded
+            isPumpManagerOnboarded = onboardingViewModel.isPumpManagerOnboarded
+        }
+    }
+
+    private var cgmManagerText: String {
+        return String(format: LocalizedString("Pair your Continuous Glucose Monitor (CGM): <b>%1$@</b>", comment: "Onboarding, Your Devices section, Pairing Your Devices view, list, CGM (1: CGM title)"),
+                      onboardingViewModel.cgmManagerTitle)
+    }
+
+    private var pumpManagerText: String {
+        return String(format: LocalizedString("Pair your Pump: <b>%1$@</b>", comment: "Onboarding, Your Devices section, Pairing Your Devices view, list, pump (1: pump title)"),
+                      onboardingViewModel.pumpManagerTitle)
+    }
+
+    private var nextButtonTitle: String? {
+        if !isCGMManagerOnboarded {
+            return LocalizedString("Pair CGM", comment: "Onboarding, Your Devices section, Pairing Your Devices view, pair CGM button, title")
+        } else {
+            return LocalizedString("Pair Pump", comment: "Onboarding, Your Devices section, Pairing Your Devices view, pair pump button, title")
+        }
+    }
+
+    private func nextButtonAction(_ completion: @escaping (Bool) -> Void) {
+        if !isCGMManagerOnboarded {
+            onboardCGMManager(completion)
+        } else if !isPumpManagerOnboarded {
+            onboardPumpManager(completion)
+        } else {
+            completion(true)
+        }
+    }
+
+    private func onboardCGMManager(_ completion: @escaping (Bool) -> Void) {
+        switch onboardingViewModel.onboardCGMManager() {
+        case .failure(let error):
+            self.alertMessage = error.localizedDescription
+            self.isAlertPresented = true
+        case .success(let success):
+            switch success {
+            case .userInteractionRequired(let viewController):
+                self.cgmManagerViewController = viewController
+                self.isSheetPresented = true
+                self.onSheetDismiss = { onboardCGMManagerComplete(completion) }
+            case .createdAndOnboarded:
+                onboardCGMManagerComplete(completion)
+            }
+        }
+    }
+
+    private func onboardCGMManagerComplete(_ completion: @escaping (Bool) -> Void) {
+        isCGMManagerOnboarded = onboardingViewModel.isCGMManagerOnboarded
+        completion(false)
+    }
+
+    private func onboardPumpManager(_ completion: @escaping (Bool) -> Void) {
+        switch onboardingViewModel.onboardPumpManager() {
+        case .failure(let error):
+            self.alertMessage = error.localizedDescription
+            self.isAlertPresented = true
+        case .success(let success):
+            switch success {
+            case .userInteractionRequired(let viewController):
+                self.pumpManagerViewController = viewController
+                self.isSheetPresented = true
+                self.onSheetDismiss = { onboardPumpManagerComplete(completion) }
+            case .createdAndOnboarded:
+                onboardPumpManagerComplete(completion)
+            }
+        }
+    }
+
+    private func onboardPumpManagerComplete(_ completion: @escaping (Bool) -> Void) {
+        isPumpManagerOnboarded = onboardingViewModel.isPumpManagerOnboarded
+        completion(isCGMManagerOnboarded && isPumpManagerOnboarded)
+    }
+
+    private var alert: Alert {
+        Alert(title: Text(LocalizedString("Error", comment: "Title of general error alert")), message: Text(alertMessage!))
+    }
+
+    private var sheet: some View {
+        managerView
+            .presentation(isModal: true)
+            .environment(\.dismiss, { isSheetPresented = false })
+    }
+
+    @ViewBuilder
+    private var managerView: some View {
+        if !isCGMManagerOnboarded {
+            CGMManagerView(cgmManagerViewController!)
+        } else {
+            PumpManagerView(pumpManagerViewController!)
+        }
+    }
+
+    fileprivate struct DeviceView: View {
+        let number: Int
+        let attributed: String
+        let checked: Bool
+
+        var body: some View {
+            HStack(spacing: 10) {
+                NumberCircle(number)
+                BodyText(attributed: attributed)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+                CheckmarkCircle()
+                    .padding(.horizontal)
+                    .opacity(checked ? 1.0: 0.0)
+            }
         }
     }
 }

--- a/TidepoolOnboarding/Views/ServiceView.swift
+++ b/TidepoolOnboarding/Views/ServiceView.swift
@@ -1,0 +1,44 @@
+//
+//  ServiceView.swift
+//  TidepoolOnboarding
+//
+//  Created by Darin Krauss on 5/5/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import SwiftUI
+import LoopKitUI
+
+struct ServiceView: UIViewControllerRepresentable {
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+    @Environment(\.dismiss) var dismiss
+
+    private let serviceViewController: ServiceViewController
+
+    init(_ serviceViewController: ServiceViewController) {
+        self.serviceViewController = serviceViewController
+    }
+
+    final class Coordinator: CompletionDelegate {
+        private let parent: ServiceView
+
+        init(_ parent: ServiceView) {
+            self.parent = parent
+        }
+
+        func completionNotifyingDidComplete(_ object: CompletionNotifying) {
+            parent.dismiss()
+        }
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        var serviceViewController = self.serviceViewController
+        serviceViewController.serviceOnboardingDelegate = onboardingViewModel
+        serviceViewController.completionDelegate = context.coordinator
+        return serviceViewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+}

--- a/TidepoolOnboardingTests/Support/AttributedStringTests.swift
+++ b/TidepoolOnboardingTests/Support/AttributedStringTests.swift
@@ -1,0 +1,127 @@
+//
+//  AttributedStringTests.swift
+//  TidepoolOnboardingTests
+//
+//  Created by Darin Krauss on 5/11/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+@testable import TidepoolOnboarding
+
+class AttributedStringTests: XCTestCase {
+    func testInitializer() {
+        let attributedString = AttributedString("This is a test")
+        XCTAssertEqual(attributedString.fragments.count, 1)
+        XCTAssertEqual(attributedString.fragments[0].string, "This is a test")
+        XCTAssertNil(attributedString.fragments[0].attributes)
+    }
+
+    func testAttributedInitializerWithPlainString() {
+        let attributedString = AttributedString(attributed: "This is a test")
+        XCTAssertEqual(attributedString.fragments.count, 1)
+        XCTAssertEqual(attributedString.fragments[0].string, "This is a test")
+        XCTAssertNil(attributedString.fragments[0].attributes)
+    }
+
+    func testAttributedInitializerWithUnparsableString() {
+        let attributedString = AttributedString(attributed: "This is an <unparseable> test")
+        XCTAssertEqual(attributedString.fragments.count, 1)
+        XCTAssertEqual(attributedString.fragments[0].string, "This is an <unparseable> test")
+        XCTAssertNil(attributedString.fragments[0].attributes)
+    }
+
+    func testAttributedInitializerWithBoldString() {
+        let attributedString = AttributedString(attributed: "This is <b>bold</b> test")
+        XCTAssertEqual(attributedString.fragments.count, 3)
+        XCTAssertEqual(attributedString.fragments[0].string, "This is ")
+        XCTAssertNil(attributedString.fragments[0].attributes)
+        XCTAssertEqual(attributedString.fragments[1].string, "bold")
+        XCTAssertEqual(attributedString.fragments[1].attributes, [.bold])
+        XCTAssertEqual(attributedString.fragments[2].string, " test")
+        XCTAssertNil(attributedString.fragments[2].attributes)
+    }
+
+    func testAttributedInitializerWithItalicString() {
+        let attributedString = AttributedString(attributed: "This is <em>italic</em> test")
+        XCTAssertEqual(attributedString.fragments.count, 3)
+        XCTAssertEqual(attributedString.fragments[0].string, "This is ")
+        XCTAssertNil(attributedString.fragments[0].attributes)
+        XCTAssertEqual(attributedString.fragments[1].string, "italic")
+        XCTAssertEqual(attributedString.fragments[1].attributes, [.italic])
+        XCTAssertEqual(attributedString.fragments[2].string, " test")
+        XCTAssertNil(attributedString.fragments[2].attributes)
+    }
+
+    func testAttributedInitializerWithBoldAndItalicString() {
+        let attributedString = AttributedString(attributed: "This is <b><em>bold and italic</em></b> test")
+        XCTAssertEqual(attributedString.fragments.count, 3)
+        XCTAssertEqual(attributedString.fragments[0].string, "This is ")
+        XCTAssertNil(attributedString.fragments[0].attributes)
+        XCTAssertEqual(attributedString.fragments[1].string, "bold and italic")
+        XCTAssertEqual(attributedString.fragments[1].attributes, [.bold, .italic])
+        XCTAssertEqual(attributedString.fragments[2].string, " test")
+        XCTAssertNil(attributedString.fragments[2].attributes)
+    }
+
+    func testAttributedInitializerWithComplexString() {
+        let attributedString = AttributedString(attributed: "<b><b/><em/></b>This is <b>bold</b>, <em>italic</em>, and <b><em><b><em>bold and italic</em></b></em></b> test<em/>")
+        XCTAssertEqual(attributedString.fragments.count, 7)
+        XCTAssertEqual(attributedString.fragments[0].string, "This is ")
+        XCTAssertNil(attributedString.fragments[0].attributes)
+        XCTAssertEqual(attributedString.fragments[1].string, "bold")
+        XCTAssertEqual(attributedString.fragments[1].attributes, [.bold])
+        XCTAssertEqual(attributedString.fragments[2].string, ", ")
+        XCTAssertNil(attributedString.fragments[2].attributes)
+        XCTAssertEqual(attributedString.fragments[3].string, "italic")
+        XCTAssertEqual(attributedString.fragments[3].attributes, [.italic])
+        XCTAssertEqual(attributedString.fragments[4].string, ", and ")
+        XCTAssertNil(attributedString.fragments[4].attributes)
+        XCTAssertEqual(attributedString.fragments[5].string, "bold and italic")
+        XCTAssertEqual(attributedString.fragments[5].attributes, [.bold, .italic])
+        XCTAssertEqual(attributedString.fragments[6].string, " test")
+        XCTAssertNil(attributedString.fragments[6].attributes)
+    }
+
+    func testBoldModifier() {
+        let attributedString = AttributedString(attributed: "normal<b>bold</b><em>italic</em>").bold()
+        XCTAssertEqual(attributedString.fragments.count, 3)
+        XCTAssertEqual(attributedString.fragments[0].string, "normal")
+        XCTAssertEqual(attributedString.fragments[0].attributes, [.bold])
+        XCTAssertEqual(attributedString.fragments[1].string, "bold")
+        XCTAssertEqual(attributedString.fragments[1].attributes, [.bold])
+        XCTAssertEqual(attributedString.fragments[2].string, "italic")
+        XCTAssertEqual(attributedString.fragments[2].attributes, [.bold, .italic])
+    }
+
+    func testItalicModifier() {
+        let attributedString = AttributedString(attributed: "normal<b>bold</b><em>italic</em>").italic()
+        XCTAssertEqual(attributedString.fragments.count, 3)
+        XCTAssertEqual(attributedString.fragments[0].string, "normal")
+        XCTAssertEqual(attributedString.fragments[0].attributes, [.italic])
+        XCTAssertEqual(attributedString.fragments[1].string, "bold")
+        XCTAssertEqual(attributedString.fragments[1].attributes, [.bold, .italic])
+        XCTAssertEqual(attributedString.fragments[2].string, "italic")
+        XCTAssertEqual(attributedString.fragments[2].attributes, [.italic])
+    }
+}
+
+class AttributedStringFragmentTests: XCTestCase {
+    func testInitializerWithoutAttributes() {
+        let fragment = AttributedString.Fragment("This is a test")
+        XCTAssertEqual(fragment.string, "This is a test")
+        XCTAssertNil(fragment.attributes)
+    }
+
+    func testInitializerWithEmptyAttributes() {
+        let fragment = AttributedString.Fragment("This is a test", attributes: [])
+        XCTAssertEqual(fragment.string, "This is a test")
+        XCTAssertNil(fragment.attributes)
+    }
+
+    func testInitializerWithNonEmptyAttributes() {
+        let fragment = AttributedString.Fragment("This is a test", attributes: [.bold, .italic])
+        XCTAssertEqual(fragment.string, "This is a test")
+        XCTAssertEqual(fragment.attributes, [.bold, .italic])
+    }
+}

--- a/TidepoolOnboardingTests/Support/AttributedStringTests.swift
+++ b/TidepoolOnboardingTests/Support/AttributedStringTests.swift
@@ -42,7 +42,7 @@ class AttributedStringTests: XCTestCase {
         XCTAssertNil(attributedString.fragments[2].attributes)
     }
 
-    func testAttributedInitializerWithItalicString() {
+    func testAttributedInitializerWithEmphasisString() {
         let attributedString = AttributedString(attributed: "This is <em>italic</em> test")
         XCTAssertEqual(attributedString.fragments.count, 3)
         XCTAssertEqual(attributedString.fragments[0].string, "This is ")
@@ -53,7 +53,18 @@ class AttributedStringTests: XCTestCase {
         XCTAssertNil(attributedString.fragments[2].attributes)
     }
 
-    func testAttributedInitializerWithBoldAndItalicString() {
+    func testAttributedInitializerWithItalicString() {
+        let attributedString = AttributedString(attributed: "This is <i>italic</i> test")
+        XCTAssertEqual(attributedString.fragments.count, 3)
+        XCTAssertEqual(attributedString.fragments[0].string, "This is ")
+        XCTAssertNil(attributedString.fragments[0].attributes)
+        XCTAssertEqual(attributedString.fragments[1].string, "italic")
+        XCTAssertEqual(attributedString.fragments[1].attributes, [.italic])
+        XCTAssertEqual(attributedString.fragments[2].string, " test")
+        XCTAssertNil(attributedString.fragments[2].attributes)
+    }
+
+    func testAttributedInitializerWithBoldAndEmphasisString() {
         let attributedString = AttributedString(attributed: "This is <b><em>bold and italic</em></b> test")
         XCTAssertEqual(attributedString.fragments.count, 3)
         XCTAssertEqual(attributedString.fragments[0].string, "This is ")
@@ -64,8 +75,19 @@ class AttributedStringTests: XCTestCase {
         XCTAssertNil(attributedString.fragments[2].attributes)
     }
 
+    func testAttributedInitializerWithBoldAndItalicString() {
+        let attributedString = AttributedString(attributed: "This is <b><i>bold and italic</i></b> test")
+        XCTAssertEqual(attributedString.fragments.count, 3)
+        XCTAssertEqual(attributedString.fragments[0].string, "This is ")
+        XCTAssertNil(attributedString.fragments[0].attributes)
+        XCTAssertEqual(attributedString.fragments[1].string, "bold and italic")
+        XCTAssertEqual(attributedString.fragments[1].attributes, [.bold, .italic])
+        XCTAssertEqual(attributedString.fragments[2].string, " test")
+        XCTAssertNil(attributedString.fragments[2].attributes)
+    }
+
     func testAttributedInitializerWithComplexString() {
-        let attributedString = AttributedString(attributed: "<b><b/><em/></b>This is <b>bold</b>, <em>italic</em>, and <b><em><b><em>bold and italic</em></b></em></b> test<em/>")
+        let attributedString = AttributedString(attributed: "<b><b/><em/></b>This is <b>bold</b>, <i>italic</i>, and <b><em><b><i>bold and italic</i></b></em></b> test<em/>")
         XCTAssertEqual(attributedString.fragments.count, 7)
         XCTAssertEqual(attributedString.fragments[0].string, "This is ")
         XCTAssertNil(attributedString.fragments[0].attributes)

--- a/TidepoolOnboardingTests/View Models/OnboardingViewModelTests.swift
+++ b/TidepoolOnboardingTests/View Models/OnboardingViewModelTests.swift
@@ -21,6 +21,10 @@ class OnboardingViewModelTests: XCTestCase {
         onboarding.prescription = .test
         onboarding.prescriberProfile = .test
         onboarding.therapySettings = .test
+        onboarding.notificationAuthorization = .notDetermined
+        onboarding.healthStoreAuthorization = .notDetermined
+        onboarding.cgmManagerIdentifier = "CGM Manager Identifier"
+        onboarding.pumpManagerIdentifier = "Pump Manager Identifier"
         onboarding.dosingEnabled = false
         onboardingViewModel = OnboardingViewModel(onboarding: onboarding, onboardingProvider: MockOnboardingProvider())
     }
@@ -52,6 +56,24 @@ class OnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(onboarding.prescription, onboardingViewModel.prescription)
     }
 
+    func testPrescriptionSetsTherapySettings() {
+        onboarding.therapySettings = nil
+        onboardingViewModel.prescription = .mock
+        XCTAssertNotNil(onboarding.therapySettings)
+    }
+
+    func testPrescriptionSetsCGMManagerIdentifier() {
+        onboarding.cgmManagerIdentifier = nil
+        onboardingViewModel.prescription = .mock
+        XCTAssertNotNil(onboarding.cgmManagerIdentifier)
+    }
+
+    func testPrescriptionSetsPumpManagerIdentifier() {
+        onboarding.pumpManagerIdentifier = nil
+        onboardingViewModel.prescription = .mock
+        XCTAssertNotNil(onboarding.pumpManagerIdentifier)
+    }
+
     func testPrescriberProfileInitialization() {
         XCTAssertEqual(onboardingViewModel.prescriberProfile, onboarding.prescriberProfile)
     }
@@ -68,6 +90,42 @@ class OnboardingViewModelTests: XCTestCase {
     func testTherapySettingsForwarding() {
         onboardingViewModel.therapySettings = TherapySettings(insulinModelSettings: .exponentialPreset(.fiasp))
         XCTAssertEqual(onboarding.therapySettings, onboardingViewModel.therapySettings)
+    }
+
+    func testNotificationAuthorizationInitialization() {
+        XCTAssertEqual(onboardingViewModel.notificationAuthorization, onboarding.notificationAuthorization)
+    }
+
+    func testNotificationAuthorizationForwarding() {
+        onboardingViewModel.notificationAuthorization = .authorized
+        XCTAssertEqual(onboarding.notificationAuthorization, onboardingViewModel.notificationAuthorization)
+    }
+
+    func testHealthStoreAuthorizationInitialization() {
+        XCTAssertEqual(onboardingViewModel.healthStoreAuthorization, onboarding.healthStoreAuthorization)
+    }
+
+    func testHealthStoreAuthorizationForwarding() {
+        onboardingViewModel.healthStoreAuthorization = .determined
+        XCTAssertEqual(onboarding.healthStoreAuthorization, onboardingViewModel.healthStoreAuthorization)
+    }
+
+    func testCGMManagerIdentifierInitialization() {
+        XCTAssertEqual(onboardingViewModel.cgmManagerIdentifier, onboarding.cgmManagerIdentifier)
+    }
+
+    func testCGMManagerIdentifierForwarding() {
+        onboardingViewModel.cgmManagerIdentifier = "New CGM Manager Identifier"
+        XCTAssertEqual(onboarding.cgmManagerIdentifier, onboardingViewModel.cgmManagerIdentifier)
+    }
+
+    func testPumpManagerIdentifierInitialization() {
+        XCTAssertEqual(onboardingViewModel.pumpManagerIdentifier, onboarding.pumpManagerIdentifier)
+    }
+
+    func testPumpManagerIdentifierForwarding() {
+        onboardingViewModel.pumpManagerIdentifier = "New Pump Manager Identifier"
+        XCTAssertEqual(onboarding.pumpManagerIdentifier, onboardingViewModel.pumpManagerIdentifier)
     }
 
     func testDosingEnabledInitialization() {


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-3464
- https://tidepool.atlassian.net/browse/LOOP-3465
- Add Pairing Your Devices view
- Integrate pump and CGM managers into onboarding
- Map prescription CGM/pump identifiers to CGM/pump manager identifiers
- Persist CGM/pump manager identifiers in view model and onboarding
- Persist notification and health store authorization in view model and onboarding
- Add CGMManagerView and PumpManagerView wrappers around UIViewControllers
- Rename TidepoolServiceView to ServiceView
- Add TProfile.mock used during onboarding skip
- Extract Bullet, CheckmarkCircle, and NumberCircle from enclosing struct
- Make custom modifiers optional for more flexibility
- Move OnboardingError into its own file
- Fix dosing enabled status if not modified by user
- Allow external trigger of destination in OnboardingSectionPageView
- Fix Your Settings initial views on restart
- Allow skip of Your Settings login and prescription
- Add Your Settings Checkpoint view
- Fix mock prescription
- Add AttributedString to allow bold and text within localized strings
- Update BodyText and related TextLists to use attributed strings
- Replace GettingToKnowTidepoolLoop view text with BodyText
- Clear prescriber profile when onboarding is reset
- Add tests