### PR TITLE
[LOOP-3791] include jailbreak app detection

### DIFF
--- a/TidepoolOnboarding.xcodeproj/project.pbxproj
+++ b/TidepoolOnboarding.xcodeproj/project.pbxproj
@@ -103,7 +103,7 @@
 		A9E56C32262E1C4600A10627 /* NumberedBodyTextList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E56C31262E1C4600A10627 /* NumberedBodyTextList.swift */; };
 		A9EBBD3D25F984560064804A /* OnboardingSectionSheetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EBBD3C25F984560064804A /* OnboardingSectionSheetButton.swift */; };
 		A9EFBD322602D09B0070E9CC /* ModalPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFBD312602D09B0070E9CC /* ModalPresentation.swift */; };
-		B483213E26C6C20B00E5F7D3 /* ValidDeviceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B483213D26C6C20B00E5F7D3 /* ValidDeviceDetector.swift */; };
+		B483213E26C6C20B00E5F7D3 /* JailbrokenDeviceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B483213D26C6C20B00E5F7D3 /* JailbrokenDeviceDetector.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -224,7 +224,7 @@
 		A9E932A52605168200E28144 /* LoopUIColorPalette+Demo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoopUIColorPalette+Demo.swift"; sourceTree = "<group>"; };
 		A9EBBD3C25F984560064804A /* OnboardingSectionSheetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSectionSheetButton.swift; sourceTree = "<group>"; };
 		A9EFBD312602D09B0070E9CC /* ModalPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPresentation.swift; sourceTree = "<group>"; };
-		B483213D26C6C20B00E5F7D3 /* ValidDeviceDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidDeviceDetector.swift; sourceTree = "<group>"; };
+		B483213D26C6C20B00E5F7D3 /* JailbrokenDeviceDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JailbrokenDeviceDetector.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -536,7 +536,7 @@
 				A95D623F2649FF410018B9EA /* AttributedString.swift */,
 				A911C223264B0FB200EF3B85 /* OnboardingError.swift */,
 				A903C79725F1443200C88786 /* OnboardingSection.swift */,
-				B483213D26C6C20B00E5F7D3 /* ValidDeviceDetector.swift */,
+				B483213D26C6C20B00E5F7D3 /* JailbrokenDeviceDetector.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -866,7 +866,7 @@
 				A9502CDA2600293200146AD3 /* BodyText.swift in Sources */,
 				A923334225C3786100D8CF69 /* Environment+Complete.swift in Sources */,
 				A916AA5125F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift in Sources */,
-				B483213E26C6C20B00E5F7D3 /* ValidDeviceDetector.swift in Sources */,
+				B483213E26C6C20B00E5F7D3 /* JailbrokenDeviceDetector.swift in Sources */,
 				A93D2B112602606E0091FB65 /* AlertOnLongPressGesture.swift in Sources */,
 				A906344A26433B9300CAFED1 /* ServiceView.swift in Sources */,
 				A9A80D852639DC6100770DA7 /* TPrescription.swift in Sources */,

--- a/TidepoolOnboarding.xcodeproj/project.pbxproj
+++ b/TidepoolOnboarding.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		A9E56C32262E1C4600A10627 /* NumberedBodyTextList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E56C31262E1C4600A10627 /* NumberedBodyTextList.swift */; };
 		A9EBBD3D25F984560064804A /* OnboardingSectionSheetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EBBD3C25F984560064804A /* OnboardingSectionSheetButton.swift */; };
 		A9EFBD322602D09B0070E9CC /* ModalPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFBD312602D09B0070E9CC /* ModalPresentation.swift */; };
+		B483213E26C6C20B00E5F7D3 /* ValidDeviceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B483213D26C6C20B00E5F7D3 /* ValidDeviceDetector.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -223,6 +224,7 @@
 		A9E932A52605168200E28144 /* LoopUIColorPalette+Demo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoopUIColorPalette+Demo.swift"; sourceTree = "<group>"; };
 		A9EBBD3C25F984560064804A /* OnboardingSectionSheetButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSectionSheetButton.swift; sourceTree = "<group>"; };
 		A9EFBD312602D09B0070E9CC /* ModalPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPresentation.swift; sourceTree = "<group>"; };
+		B483213D26C6C20B00E5F7D3 /* ValidDeviceDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidDeviceDetector.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -534,6 +536,7 @@
 				A95D623F2649FF410018B9EA /* AttributedString.swift */,
 				A911C223264B0FB200EF3B85 /* OnboardingError.swift */,
 				A903C79725F1443200C88786 /* OnboardingSection.swift */,
+				B483213D26C6C20B00E5F7D3 /* ValidDeviceDetector.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -863,6 +866,7 @@
 				A9502CDA2600293200146AD3 /* BodyText.swift in Sources */,
 				A923334225C3786100D8CF69 /* Environment+Complete.swift in Sources */,
 				A916AA5125F6F05600B7CEF2 /* OnboardingViewModel+Preview.swift in Sources */,
+				B483213E26C6C20B00E5F7D3 /* ValidDeviceDetector.swift in Sources */,
 				A93D2B112602606E0091FB65 /* AlertOnLongPressGesture.swift in Sources */,
 				A906344A26433B9300CAFED1 /* ServiceView.swift in Sources */,
 				A9A80D852639DC6100770DA7 /* TPrescription.swift in Sources */,

--- a/TidepoolOnboarding/Support/JailbrokenDeviceDetector.swift
+++ b/TidepoolOnboarding/Support/JailbrokenDeviceDetector.swift
@@ -1,5 +1,5 @@
 //
-//  ValidDeviceDetector.swift
+//  JailbrokenDeviceDetector.swift
 //  TidepoolOnboarding
 //
 //  Created by Nathaniel Hamming on 2021-08-13.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-struct ValidDeviceDetector {
+struct JailbrokenDeviceDetector {
     static public func isJailbrokenDevice() -> Bool {
         #if targetEnvironment(simulator)
         return false
@@ -17,6 +17,7 @@ struct ValidDeviceDetector {
         {
             return true
         }
+
 
         if FileManager.default.fileExists(atPath: "/Applications/Cydia.app") ||
             FileManager.default.fileExists(atPath: "/Library/MobileSubstrate/MobileSubstrate.dylib") ||

--- a/TidepoolOnboarding/Support/ValidDeviceDetector.swift
+++ b/TidepoolOnboarding/Support/ValidDeviceDetector.swift
@@ -1,0 +1,34 @@
+//
+//  ValidDeviceDetector.swift
+//  TidepoolOnboarding
+//
+//  Created by Nathaniel Hamming on 2021-08-13.
+//
+
+import UIKit
+
+struct ValidDeviceDetector {
+    static public func isJailbrokenDevice() -> Bool {
+        #if targetEnvironment(simulator)
+        return false
+        #else
+        if let url = URL(string: "cydia://"),
+           UIApplication.shared.canOpenURL(url)
+        {
+            return true
+        }
+
+        if FileManager.default.fileExists(atPath: "/Applications/Cydia.app") ||
+            FileManager.default.fileExists(atPath: "/Library/MobileSubstrate/MobileSubstrate.dylib") ||
+            FileManager.default.fileExists(atPath: "/bin/bash") ||
+            FileManager.default.fileExists(atPath: "/usr/sbin/sshd") ||
+            FileManager.default.fileExists(atPath: "/etc/apt") ||
+            FileManager.default.fileExists(atPath: "/usr/bin/ssh")
+        {
+            return true
+        }
+
+        return false
+        #endif
+    }
+}

--- a/TidepoolOnboarding/View Models/OnboardingViewModel.swift
+++ b/TidepoolOnboarding/View Models/OnboardingViewModel.swift
@@ -215,21 +215,35 @@ class OnboardingViewModel: ObservableObject, CGMManagerOnboarding, PumpManagerOn
 
     func verifyDevice(completion: @escaping (OnboardingError?) -> Void) {
         guard deviceValid == nil else {
-            log.debug("%{public}@ device was already validated. deviceValid: %{public}@", #function, deviceValid! ? "Yes" : "No")
+            log.info("%{public}@ device was already validated. deviceValid: %{public}@", #function, deviceValid! ? "Yes" : "No")
             completion(nil)
             return
         }
 
         guard let tidepoolService = tidepoolService else {
-            log.debug("%{public}@ tidepool service does not exist", #function)
+            log.info("%{public}@ tidepool service does not exist", #function)
             completion(OnboardingError.unexpectedState)
             return
         }
 
-        // If the device does not require verification (i.e. simulator) or DeviceCheck is not supported, just mark as valid
-        guard deviceRequiresVerification, DCDevice.current.isSupported else {
-            log.debug("%{public}@ device requires verification: %{public}@; is device supported: %{public}@", #function, deviceRequiresVerification ? "Yes" : "No", DCDevice.current.isSupported ? "Yes" : "No")
+        // If the device does not require verification (i.e. simulator), mark as valid
+        guard deviceRequiresVerification else {
+            log.info("%{public}@ device does not require verification: %{public}@; is device supported: %{public}@", #function, deviceRequiresVerification ? "Yes" : "No", DCDevice.current.isSupported ? "Yes" : "No")
             self.deviceValid = true
+            completion(nil)
+            return
+        }
+
+        // if the device does not support DCDevice API, mark as invalid
+        guard DCDevice.current.isSupported else {
+            log.info("%{public}@ DCDevice API is not supported. Without this API, the device token cannot be generated and this device automatically fails validation", #function)
+            self.deviceValid = false
+            completion(nil)
+            return
+        }
+
+        guard !ValidDeviceDetector.isJailbrokenDevice() else {
+            self.deviceValid = false
             completion(nil)
             return
         }
@@ -237,7 +251,7 @@ class OnboardingViewModel: ObservableObject, CGMManagerOnboarding, PumpManagerOn
         DCDevice.current.generateToken { token, error in
             DispatchQueue.main.async {
                 guard error == nil, let token = token else {
-                    self.log.debug("%{public}@ device token generation failed. error: %{public}@", #function, error.debugDescription)
+                    self.log.info("%{public}@ device token generation failed. error: %{public}@", #function, error.debugDescription)
                     completion(OnboardingError.unexpectedError)
                     return
                 }

--- a/TidepoolOnboarding/View Models/OnboardingViewModel.swift
+++ b/TidepoolOnboarding/View Models/OnboardingViewModel.swift
@@ -228,8 +228,15 @@ class OnboardingViewModel: ObservableObject, CGMManagerOnboarding, PumpManagerOn
 
         // If the device does not require verification (i.e. simulator), mark as valid
         guard deviceRequiresVerification else {
-            log.info("%{public}@ device does not require verification: %{public}@; is device supported: %{public}@", #function, deviceRequiresVerification ? "Yes" : "No", DCDevice.current.isSupported ? "Yes" : "No")
+            log.info("%{public}@ device does not require verification", #function)
             self.deviceValid = true
+            completion(nil)
+            return
+        }
+
+        guard !JailbrokenDeviceDetector.isJailbrokenDevice() else {
+            log.info("%{public}@ device is considered to be jailbroken", #function)
+            self.deviceValid = false
             completion(nil)
             return
         }
@@ -237,12 +244,6 @@ class OnboardingViewModel: ObservableObject, CGMManagerOnboarding, PumpManagerOn
         // if the device does not support DCDevice API, mark as invalid
         guard DCDevice.current.isSupported else {
             log.info("%{public}@ DCDevice API is not supported. Without this API, the device token cannot be generated and this device automatically fails validation", #function)
-            self.deviceValid = false
-            completion(nil)
-            return
-        }
-
-        guard !ValidDeviceDetector.isJailbrokenDevice() else {
             self.deviceValid = false
             completion(nil)
             return


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3791

It is known that this method of detecting a jailbroken device is not robust. However, Cydia package manager is a common method.

Also note that if the DCDevice API is not support, the device is considered to be invalid.