### PR TITLE
[LOOP-3475/3476] Display correct prescriber name and prescription date

### DIFF
--- a/TidepoolOnboarding/Extensions/TPrescription.swift
+++ b/TidepoolOnboarding/Extensions/TPrescription.swift
@@ -88,13 +88,15 @@ extension TPrescription {
                                                   training: .inModule,
                                                   therapySettings: .initial,
                                                   prescriberTermsAccepted: true,
-                                                  state: .submitted,
-                                                  createdTime: dateFormatter.date(from: "2021-04-28T20:19:30.841Z"),
-                                                  createdUserId: "42cb2e2f-b0e7-4168-a30f-a2738777027a")
+                                                  state: .submitted)
+        let revision = TPrescription.Revision(revisionId: 0,
+                                              attributes: attributes,
+                                              createdTime: dateFormatter.date(from: "2021-04-28T20:19:30.841Z"),
+                                              createdUserId: "42cb2e2f-b0e7-4168-a30f-a2738777027a")
         return TPrescription(id: "6089c35220398b38a71f2103",
                              patientUserId: "dd8373e3-992e-4801-a17e-08b49b4f3ade",
                              state: .claimed,
-                             latestRevision: TPrescription.Revision(revisionId: 0, attributes: attributes),
+                             latestRevision: revision,
                              prescriberUserId: "42cb2e2f-b0e7-4168-a30f-a2738777027a",
                              createdTime: dateFormatter.date(from: "2021-04-28T20:19:30.841Z"),
                              createdUserId: "42cb2e2f-b0e7-4168-a30f-a2738777027a",

--- a/TidepoolOnboarding/View Models/OnboardingViewModel.swift
+++ b/TidepoolOnboarding/View Models/OnboardingViewModel.swift
@@ -337,14 +337,8 @@ class OnboardingViewModel: ObservableObject, CGMManagerOnboarding, PumpManagerOn
         tidepoolService.tapi.getProfile(userId: prescription.prescriberUserId) { result in
             DispatchQueue.main.async {
                 switch result {
-                case .failure:
-                    // completion(error.onboardingError)
-                    // TODO: https://tidepool.atlassian.net/browse/LOOP-3475
-                    // The backend does not *yet* automatically create a sharing connection between the prescriber account
-                    // and the prescription account. This API call will fail unless the two accounts had a previous
-                    // sharing connection. To allow onboarding to function, create a placeholder prescriber profile.
-                    self.prescriberProfile = TProfile(fullName: "Unknown Prescriber")
-                    completion(nil)
+                case .failure(let error):
+                    completion(error.onboardingError)
                 case .success(let profile):
                     self.prescriberProfile = profile
                     completion(nil)
@@ -354,7 +348,7 @@ class OnboardingViewModel: ObservableObject, CGMManagerOnboarding, PumpManagerOn
     }
 
     private func constructInitialTherapySettingsViewModel() -> TherapySettingsViewModel {
-        guard let datePrescribed = prescription?.modifiedTime ?? prescription?.createdTime,   // TODO: https://tidepool.atlassian.net/browse/LOOP-3476
+        guard let datePrescribed = prescription?.submittedTime ?? prescription?.modifiedTime ?? prescription?.createdTime,
               let providerName = prescriberProfile?.fullName,
               let therapySettings = prescription?.therapySettings else {
             preconditionFailure("Must have prescription and prescriber profile to construct therapy settings view model")


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-3475
- https://tidepool.atlassian.net/browse/LOOP-3476
- Remove temporary workaround for unavailable prescriber name
- Use correct prescription submitted date