### PR TITLE
COASTAL-837: Adds ability to skip only individual device onboarding

### DIFF
--- a/TidepoolOnboarding/Extensions/TPrescription.swift
+++ b/TidepoolOnboarding/Extensions/TPrescription.swift
@@ -43,6 +43,9 @@ extension TPrescription {
 
 extension TPrescription {
     static var mock: TPrescription {
+        let omnipod = "6678c377-928c-49b3-84c1-19e2dafaff8d"    // Hard-coded Tidepool backend device identifier
+        let coastal = "e4a46eda-02f9-4faf-b8f4-ef7b40d02e4f"    // Hard-coded Tidepool backend device identifier
+        let dexcom = "d25c3f1b-a2e8-44e2-b3a3-fd07806fc245"    // Hard-coded Tidepool backend device identifier
         let initialSettings = TPrescription.Attributes.InitialSettings(bloodGlucoseUnits: .milligramsPerDeciliter,
                                                                        basalRateSchedule: [
                                                                         TPrescription.Attributes.InitialSettings.BasalRateStart(start: .hours(0), rate: 1.0),
@@ -70,8 +73,8 @@ extension TPrescription {
                                                                        ],
                                                                        basalRateMaximum: TPrescription.Attributes.InitialSettings.BasalRateMaximum(4.5, .unitsPerHour),
                                                                        bolusAmountMaximum: TPrescription.Attributes.InitialSettings.BolusAmountMaximum(10, .units),
-                                                                       pumpId: "e4a46eda-02f9-4faf-b8f4-ef7b40d02e4f",
-                                                                       cgmId: "d25c3f1b-a2e8-44e2-b3a3-fd07806fc245")
+                                                                       pumpId: coastal,
+                                                                       cgmId: dexcom)
         let attributes = TPrescription.Attributes(accountType: .caregiver,
                                                   caregiverFirstName: "Parent",
                                                   caregiverLastName: "Doe",

--- a/TidepoolOnboarding/Extensions/TPrescription.swift
+++ b/TidepoolOnboarding/Extensions/TPrescription.swift
@@ -70,7 +70,7 @@ extension TPrescription {
                                                                        ],
                                                                        basalRateMaximum: TPrescription.Attributes.InitialSettings.BasalRateMaximum(4.5, .unitsPerHour),
                                                                        bolusAmountMaximum: TPrescription.Attributes.InitialSettings.BolusAmountMaximum(10, .units),
-                                                                       pumpId: "6678c377-928c-49b3-84c1-19e2dafaff8d",
+                                                                       pumpId: "e4a46eda-02f9-4faf-b8f4-ef7b40d02e4f",
                                                                        cgmId: "d25c3f1b-a2e8-44e2-b3a3-fd07806fc245")
         let attributes = TPrescription.Attributes(accountType: .caregiver,
                                                   caregiverFirstName: "Parent",

--- a/TidepoolOnboarding/View Models/OnboardingViewModel.swift
+++ b/TidepoolOnboarding/View Models/OnboardingViewModel.swift
@@ -574,7 +574,7 @@ class OnboardingViewModel: ObservableObject, CGMManagerOnboarding, PumpManagerOn
             }
         }
     }
-
+    
     private func skipCompleteYourDevicesDevices(forceSimulators: Bool, completion: @escaping () -> Void) {
         guard forceSimulators else {
             completion()
@@ -582,45 +582,53 @@ class OnboardingViewModel: ObservableObject, CGMManagerOnboarding, PumpManagerOn
         }
 
         if onboardingProvider.activeCGMManager == nil {
-            self.cgmManagerIdentifier = MockCGMManager.managerIdentifier
-            switch onboardCGMManager() {
-            case .success(let result):
-                switch result {
-                case .userInteractionRequired(_):
-                    log.error("%{public}@ Unable to force CGM simulator onboarding when user interaction required", #function)
-                case .createdAndOnboarded(let cgmManager):
-                    if let cgmManager = cgmManager as? MockCGMManager {
-                        let parameters = MockCGMDataSource.Model.SineCurveParameters(baseGlucose: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 120),
-                                                                                     amplitude: HKQuantity(unit:.milligramsPerDeciliter, doubleValue: 40),
-                                                                                     period: .hours(6),
-                                                                                     referenceDate: Date())
-                        cgmManager.dataSource = MockCGMDataSource(model: .sineCurve(parameters: parameters))
-                        cgmManager.backfillData(datingBack: .hours(3))
-                    }
-                }
-            case .failure(let error):
-                log.error("%{public}@ Failure to force CGM simulator onboarding [error=%{public}@]", #function, String(describing: error))
-            }
+            skipCompleteYourDevicesCGMManager()
         }
-
         if onboardingProvider.activePumpManager == nil {
-            self.pumpManagerIdentifier = MockPumpManager.managerIdentifier
-            switch onboardPumpManager() {
-            case .success(let result):
-                switch result {
-                case .userInteractionRequired(_):
-                    log.error("%{public}@ Unable to force pump simulator onboarding when user interaction required", #function)
-                case .createdAndOnboarded(_):
-                    break
-                }
-            case .failure(let error):
-                log.error("%{public}@ Failure to force pump simulator onboarding [error=%{public}@]", #function, String(describing: error))
-            }
+            skipCompleteYourDevicesPumpManager()
         }
-
         completion()
     }
 
+    func skipCompleteYourDevicesCGMManager() {
+        cgmManagerIdentifier = MockCGMManager.managerIdentifier
+        switch onboardCGMManager() {
+        case .success(let result):
+            switch result {
+            case .userInteractionRequired(_):
+                log.error("%{public}@ Unable to force CGM simulator onboarding when user interaction required", #function)
+            case .createdAndOnboarded(let cgmManager):
+                if let cgmManager = cgmManager as? MockCGMManager {
+                    let parameters = MockCGMDataSource.Model.SineCurveParameters(baseGlucose: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 120),
+                                                                                 amplitude: HKQuantity(unit:.milligramsPerDeciliter, doubleValue: 40),
+                                                                                 period: .hours(6),
+                                                                                 referenceDate: Date())
+                    cgmManager.dataSource = MockCGMDataSource(model: .sineCurve(parameters: parameters))
+                    cgmManager.backfillData(datingBack: .hours(3))
+                }
+                isCGMManagerOnboarded = true
+            }
+        case .failure(let error):
+            log.error("%{public}@ Failure to force CGM simulator onboarding [error=%{public}@]", #function, String(describing: error))
+        }
+    }
+    
+    func skipCompleteYourDevicesPumpManager() {
+        self.pumpManagerIdentifier = MockPumpManager.managerIdentifier
+        switch onboardPumpManager() {
+        case .success(let result):
+            switch result {
+            case .userInteractionRequired(_):
+                log.error("%{public}@ Unable to force pump simulator onboarding when user interaction required", #function)
+            case .createdAndOnboarded(_):
+                isPumpManagerOnboarded = true
+                break
+            }
+        case .failure(let error):
+            log.error("%{public}@ Failure to force pump simulator onboarding [error=%{public}@]", #function, String(describing: error))
+        }
+    }
+    
     private func skipCompleteGetLooping(completion: @escaping () -> Void) {
         if dosingEnabled == nil {
             self.dosingEnabled = true
@@ -739,7 +747,7 @@ fileprivate extension TPrescription {
     var pumpManagerIdentifier: String? {
         switch latestRevision?.attributes?.initialSettings?.pumpId {
         case "6678c377-928c-49b3-84c1-19e2dafaff8d":    // Hard-coded Tidepool backend device identifier
-            return "Omnipod"
+            return "AccuChekSolo"
         default:
             return nil
         }

--- a/TidepoolOnboarding/View Models/OnboardingViewModel.swift
+++ b/TidepoolOnboarding/View Models/OnboardingViewModel.swift
@@ -748,6 +748,8 @@ fileprivate extension TPrescription {
         switch latestRevision?.attributes?.initialSettings?.pumpId {
         case "e4a46eda-02f9-4faf-b8f4-ef7b40d02e4f":    // Hard-coded Tidepool backend device identifier
             return "AccuChekSolo"
+        case "6678c377-928c-49b3-84c1-19e2dafaff8d":    // Hard-coded Tidepool backend device identifier
+            return "Omnipod"
         default:
             return nil
         }

--- a/TidepoolOnboarding/View Models/OnboardingViewModel.swift
+++ b/TidepoolOnboarding/View Models/OnboardingViewModel.swift
@@ -746,7 +746,7 @@ fileprivate extension TPrescription {
 
     var pumpManagerIdentifier: String? {
         switch latestRevision?.attributes?.initialSettings?.pumpId {
-        case "6678c377-928c-49b3-84c1-19e2dafaff8d":    // Hard-coded Tidepool backend device identifier
+        case "e4a46eda-02f9-4faf-b8f4-ef7b40d02e4f":    // Hard-coded Tidepool backend device identifier
             return "AccuChekSolo"
         default:
             return nil

--- a/TidepoolOnboarding/Views/Sections/YourDevicesViews.swift
+++ b/TidepoolOnboarding/Views/Sections/YourDevicesViews.swift
@@ -258,6 +258,7 @@ fileprivate struct YourDevicesPairingYourDevicesView: View {
     @EnvironmentObject var onboardingViewModel: OnboardingViewModel
 
     @State private var alertMessage: String?
+    @State private var alertAction: (() -> Void)?
     @State private var isAlertPresented = false
 
     @State private var cgmManagerViewController: CGMManagerViewController?
@@ -277,8 +278,26 @@ fileprivate struct YourDevicesPairingYourDevicesView: View {
             VStack(alignment: .leading, spacing: 30) {
                 DeviceView(number: 1, attributed: cgmManagerText, checked: onboardingViewModel.isCGMManagerOnboarded)
                     .sheet(isPresented: $isCGMManagerSheetPresented, onDismiss: onSheetDismiss) { onboardCGMManagerSheet }
+                    // Can't use `.alertOnLongPressGesture` because we already have an .alert below :(
+                    .onLongPressGesture(minimumDuration: 2) {
+                        if onboardingViewModel.allowDebugFeatures { // NOTE: DEBUG FEATURES - DEBUG AND TEST ONLY
+                            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                            alertMessage = "Are you sure you want to skip pairing a CGM and use the CGM simulator?" // Not localized
+                            alertAction = onboardingViewModel.skipCompleteYourDevicesCGMManager
+                            isAlertPresented = true
+                        }
+                    }
                 DeviceView(number: 2, attributed: pumpManagerText, checked: onboardingViewModel.isPumpManagerOnboarded)
                     .sheet(isPresented: $isPumpManagerSheetPresented, onDismiss: onSheetDismiss) { onboardPumpManagerSheet }
+                    // Can't use `.alertOnLongPressGesture` because we already have an .alert below :(
+                    .onLongPressGesture(minimumDuration: 2) {
+                        if onboardingViewModel.allowDebugFeatures { // NOTE: DEBUG FEATURES - DEBUG AND TEST ONLY
+                            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                            alertMessage = "Are you sure you want to skip pairing a Pump and use the Pump simulator?" // Not localized
+                            alertAction = onboardingViewModel.skipCompleteYourDevicesPumpManager
+                            isAlertPresented = true
+                        }
+                    }
             }
             .padding(.vertical)
             Paragraph(LocalizedString("If you do not yet have both devices, or you need to stop for any reason, you can pause and return to this point later.", comment: "Onboarding, Your Devices section, Pairing Your Devices view, paragraph 4"))
@@ -402,7 +421,13 @@ fileprivate struct YourDevicesPairingYourDevicesView: View {
     }
 
     private var alert: Alert {
-        Alert(title: Text(LocalizedString("Error", comment: "Title of general error alert")), message: Text(alertMessage!))
+        if let action = alertAction {
+            return Alert(title: Text(alertMessage!),
+                         primaryButton: .cancel(),
+                         secondaryButton: .destructive(Text("Yes"), action: action))
+        } else {
+            return Alert(title: Text(LocalizedString("Error", comment: "Title of general error alert")), message: Text(alertMessage!))
+        }
     }
 
     fileprivate struct DeviceView: View {

--- a/TidepoolOnboarding/Views/Sections/YourDevicesViews.swift
+++ b/TidepoolOnboarding/Views/Sections/YourDevicesViews.swift
@@ -315,7 +315,7 @@ fileprivate struct YourDevicesPairingYourDevicesView: View {
     }
 
     private var pumpManagerText: String {
-        return String(format: LocalizedString("Connect your Pump: <b>%1$@</b>", comment: "Onboarding, Your Devices section, Pairing Your Devices view, list, pump (1: pump title)"),
+        return String(format: LocalizedString("Pair your Pump: <b>%1$@</b>", comment: "Onboarding, Your Devices section, Pairing Your Devices view, list, pump (1: pump title)"),
                       onboardingViewModel.pumpManagerTitle)
     }
 
@@ -323,7 +323,7 @@ fileprivate struct YourDevicesPairingYourDevicesView: View {
         if !onboardingViewModel.isCGMManagerOnboarded {
             return LocalizedString("Pair CGM", comment: "Onboarding, Your Devices section, Pairing Your Devices view, pair CGM button, title")
         } else {
-            return LocalizedString("Connect Pump", comment: "Onboarding, Your Devices section, Pairing Your Devices view, connect pump button, title")
+            return LocalizedString("Pair Pump", comment: "Onboarding, Your Devices section, Pairing Your Devices view, pair pump button, title")
         }
     }
 

--- a/TidepoolOnboarding/Views/Sections/YourDevicesViews.swift
+++ b/TidepoolOnboarding/Views/Sections/YourDevicesViews.swift
@@ -315,7 +315,7 @@ fileprivate struct YourDevicesPairingYourDevicesView: View {
     }
 
     private var pumpManagerText: String {
-        return String(format: LocalizedString("Pair your Pump: <b>%1$@</b>", comment: "Onboarding, Your Devices section, Pairing Your Devices view, list, pump (1: pump title)"),
+        return String(format: LocalizedString("Connect your Pump: <b>%1$@</b>", comment: "Onboarding, Your Devices section, Pairing Your Devices view, list, pump (1: pump title)"),
                       onboardingViewModel.pumpManagerTitle)
     }
 
@@ -323,7 +323,7 @@ fileprivate struct YourDevicesPairingYourDevicesView: View {
         if !onboardingViewModel.isCGMManagerOnboarded {
             return LocalizedString("Pair CGM", comment: "Onboarding, Your Devices section, Pairing Your Devices view, pair CGM button, title")
         } else {
-            return LocalizedString("Pair Pump", comment: "Onboarding, Your Devices section, Pairing Your Devices view, pair pump button, title")
+            return LocalizedString("Connect Pump", comment: "Onboarding, Your Devices section, Pairing Your Devices view, connect pump button, title")
         }
     }
 


### PR DESCRIPTION
Allows you to long-press on each of the Pair CGM and Pair Pump text in Your Devices to facilitate development and testing of the Coastal Pump onboarding
https://tidepool.atlassian.net/browse/COASTAL-837